### PR TITLE
Rename layers in the tree, with names remembered per marketplace record

### DIFF
--- a/src/lib/modules/editor/components/TreePanel.svelte
+++ b/src/lib/modules/editor/components/TreePanel.svelte
@@ -58,6 +58,7 @@
     [TAG.pvStruct]: "preview",
   };
 
+  /** The derived label — what a layer is called until it is renamed. */
   export function layerLabel(l: Layer) {
     let s = l.kind === "raw" ? (rawNames[l.tag] ?? `0x${l.tag.toString(16)}`) : kindNames[l.kind];
 
@@ -136,6 +137,17 @@
       ids: $selected.map((l) => l.id),
       patch: { [key]: !$selected[0]?.[key] },
     });
+
+  // Renaming: the row swaps for an input. The name is editor-only — the .bin has no string node
+  // for a layer — so it lives as long as the document does and is lost on reload.
+  let renaming = $state.raw<NodeId | null>(null);
+
+  function commitRename(l: Layer, value: string) {
+    const name = value.trim();
+
+    renaming = null;
+    if (name !== (l.name ?? "")) layerFlagsSet({ ids: [l.id], patch: { name: name || undefined } });
+  }
 
   // accordion: closed by default, keyed by layer id — ids survive an immutable edit, object
   // references don't
@@ -311,6 +323,11 @@
 />
 
 {#snippet layerActions()}
+  {#if $sel && $selected.length === 1}
+    <MenuItem onClick={() => (renaming = $sel)}>
+      <Icon name="pencil" size={14} /> Rename
+    </MenuItem>
+  {/if}
   <MenuItem onClick={duplicateRequested}>
     <Icon name="copy" size={14} /> Duplicate
   </MenuItem>
@@ -382,52 +399,75 @@
 {#snippet treeNode(l: Layer, depth: number)}
   <!-- reversed: layer order is draw order, so the last one is topmost and goes first -->
   {@const kids = [...childrenOf(l)].reverse()}
-  <button
-    type="button"
-    class="node-row"
-    class:selected={isPicked(l.id)}
-    class:primary={$sel === l.id && $selected.length > 1}
-    class:dragging={drag === l.id}
-    class:drop-into={dropAt?.id === l.id && dropAt.into}
-    class:drop-before={dropAt?.id === l.id && !dropAt.into && !dropAt.after}
-    class:drop-after={dropAt?.id === l.id && !dropAt.into && dropAt.after}
-    style="padding-inline-start: {0.5 + depth * 0.75}rem"
-    draggable="true"
-    onclick={(e) => onRowClick(l.id, e)}
-    oncontextmenu={(e) => onRowMenu(l.id, e)}
-    ondragstart={(e) => onDragStart(l.id, e)}
-    ondragover={(e) => onDragOver(l, e)}
-    ondrop={(e) => onDrop(l, e)}
-    ondragend={() => (drag = dropAt = null)}
-  >
-    {#if kids.length}
-      <Icon
-        name="chevron-right"
-        size={12}
-        class={openNodes.has(l.id) ? "chevron open" : "chevron"}
-        onclick={(e: MouseEvent) => toggleOpen(l.id, e)}
-      />
-    {:else}
+  {#if renaming === l.id}
+    <!-- an <input> can't live inside the row's own <button>, so the whole row swaps -->
+    <div class="node-row" style="padding-inline-start: {0.5 + depth * 0.75}rem">
       <span class="chevron-spacer"></span>
-    {/if}
-    <Icon name={kindIcons[l.kind]} size={14} class="node-icon" />
-    <span class="label">{layerLabel(l)}</span>
-    <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <span class="flags">
-      <Icon
-        name={l.hidden ? "eye-off" : "eye"}
-        size={12}
-        class={l.hidden ? "flag on" : "flag"}
-        onclick={(e: MouseEvent) => toggleFlag(e, l, "hidden")}
+      <Icon name={kindIcons[l.kind]} size={14} class="node-icon" />
+      <input
+        class="rename"
+        value={l.name ?? ""}
+        placeholder={layerLabel(l)}
+        onblur={(e) => commitRename(l, e.currentTarget.value)}
+        onkeydown={(e) => {
+          if (e.key === "Enter") e.currentTarget.blur();
+          else if (e.key === "Escape") renaming = null;
+        }}
+        {@attach (el: HTMLInputElement) => {
+          el.focus();
+          el.select();
+        }}
       />
-      <Icon
-        name={l.locked ? "lock" : "lock-open"}
-        size={12}
-        class={l.locked ? "flag on" : "flag"}
-        onclick={(e: MouseEvent) => toggleFlag(e, l, "locked")}
-      />
-    </span>
-  </button>
+    </div>
+  {:else}
+    <button
+      type="button"
+      class="node-row"
+      class:selected={isPicked(l.id)}
+      class:primary={$sel === l.id && $selected.length > 1}
+      class:dragging={drag === l.id}
+      class:drop-into={dropAt?.id === l.id && dropAt.into}
+      class:drop-before={dropAt?.id === l.id && !dropAt.into && !dropAt.after}
+      class:drop-after={dropAt?.id === l.id && !dropAt.into && dropAt.after}
+      style="padding-inline-start: {0.5 + depth * 0.75}rem"
+      draggable="true"
+      onclick={(e) => onRowClick(l.id, e)}
+      ondblclick={() => (renaming = l.id)}
+      oncontextmenu={(e) => onRowMenu(l.id, e)}
+      ondragstart={(e) => onDragStart(l.id, e)}
+      ondragover={(e) => onDragOver(l, e)}
+      ondrop={(e) => onDrop(l, e)}
+      ondragend={() => (drag = dropAt = null)}
+    >
+      {#if kids.length}
+        <Icon
+          name="chevron-right"
+          size={12}
+          class={openNodes.has(l.id) ? "chevron open" : "chevron"}
+          onclick={(e: MouseEvent) => toggleOpen(l.id, e)}
+        />
+      {:else}
+        <span class="chevron-spacer"></span>
+      {/if}
+      <Icon name={kindIcons[l.kind]} size={14} class="node-icon" />
+      <span class="label">{l.name || layerLabel(l)}</span>
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
+      <span class="flags">
+        <Icon
+          name={l.hidden ? "eye-off" : "eye"}
+          size={12}
+          class={l.hidden ? "flag on" : "flag"}
+          onclick={(e: MouseEvent) => toggleFlag(e, l, "hidden")}
+        />
+        <Icon
+          name={l.locked ? "lock" : "lock-open"}
+          size={12}
+          class={l.locked ? "flag on" : "flag"}
+          onclick={(e: MouseEvent) => toggleFlag(e, l, "locked")}
+        />
+      </span>
+    </button>
+  {/if}
   {#if kids.length && openNodes.has(l.id)}
     {#each kids as c (c.id)}
       {@render treeNode(c, depth + 1)}
@@ -542,6 +582,16 @@
   :global(.flag.on),
   .node-row:hover :global(.flag) {
     opacity: 0.75;
+  }
+  .rename {
+    flex: 1;
+    min-width: 0;
+    border: none;
+    background: transparent;
+    padding: 0;
+    font: inherit;
+    color: var(--color-text);
+    outline: none;
   }
   .label {
     overflow: hidden;

--- a/src/lib/modules/editor/core/document/doc.ts
+++ b/src/lib/modules/editor/core/document/doc.ts
@@ -281,9 +281,9 @@ const SERVICE = new Set<number>([
   TAG.pivot,
   TAG.fmt,
   TAG.frame,
-  0x5a,
-  0x5b,
-  0x5f,
+  TAG.arc,
+  TAG.arcClipped,
+  TAG.slot,
 ]);
 
 /** A digit strip is tagged 0x60 in most faces, but the renderer also treats any node with a
@@ -331,7 +331,7 @@ function toLayer(n: FaceNode, ids: readonly ImageId[]): Layer {
     };
     const pivot = sub(n, TAG.pivot);
     const spec = parseArcSpec(n);
-    const slot = sub(n, 0x5f);
+    const slot = sub(n, TAG.slot);
 
     if (pivot)
       return {
@@ -492,7 +492,7 @@ function toNode(l: Layer, runAt: ReadonlyMap<string, number[]>): FaceNode {
     out[2] = l.active;
     out.set(l.metrics, 3);
     out.set(v, 3 + l.metrics.length);
-    subs.push({ tag: 0x5f, hex: hex(out) });
+    subs.push({ tag: TAG.slot, hex: hex(out) });
   }
   return { tag: l.tag, subs };
 }

--- a/src/lib/modules/editor/core/document/edits.ts
+++ b/src/lib/modules/editor/core/document/edits.ts
@@ -18,10 +18,10 @@ import {
 } from "./doc";
 import { SLOT_SEL_ID, isSlotSel } from "./sources";
 
-const childrenOf = (l: Layer): readonly Layer[] =>
+export const childrenOf = (l: Layer): readonly Layer[] =>
   l.kind === "group" ? l.children : l.kind === "raw" ? (l.children ?? []) : [];
 
-const withChildren = (l: Layer, children: readonly Layer[]): Layer =>
+export const withChildren = (l: Layer, children: readonly Layer[]): Layer =>
   l.kind === "group" ? { ...l, children } : l.kind === "raw" ? { ...l, children } : l;
 
 export function findLayer(doc: Doc, id: NodeId): Layer | null {

--- a/src/lib/modules/editor/core/document/factory.ts
+++ b/src/lib/modules/editor/core/document/factory.ts
@@ -101,7 +101,7 @@ export const newGroup = (): GroupLayer => ({
 export function newRing(): RingLayer {
   const d = 200;
   const spec: ArcSpec = {
-    kind: 0x5a,
+    kind: TAG.arc,
     min: 0,
     max: 100,
     start: 0,

--- a/src/lib/modules/editor/core/document/names.ts
+++ b/src/lib/modules/editor/core/document/names.ts
@@ -1,0 +1,68 @@
+// Layer names live beside the document, not in it: the format has no string node for a layer, so
+// a name can't ride along in the .bin. localStorage keeps them, keyed by the marketplace record
+// the face was opened from — reopening the same watchface from /my brings its names back, on this
+// browser.
+//
+// ponytail: a layer is addressed by its position in the tree ("main/3/1"), because a NodeId is
+// minted fresh on every parse and means nothing across sessions. Inserting or deleting a sibling
+// therefore shifts the names below it; renaming again fixes it. Upgrade path, if that ever bites:
+// key by something the layer carries (kind + coordinates + frame ids). Never pruned either — a
+// deleted watchface leaves a few hundred bytes nothing looks up.
+import type { Doc, Layer } from "./doc";
+import { childrenOf, withChildren } from "./edits";
+
+const STORE = "fmc_layer_names";
+
+type Names = Record<string, string>;
+
+const all = (): Record<string, Names> => {
+  try {
+    return JSON.parse(localStorage.getItem(STORE) || "{}") as Record<string, Names>;
+  } catch {
+    return {};
+  }
+};
+
+// The model calls this on every document change, which during a drag means once per frame — so
+// the map is compared before it is written, and only a rename actually reaches localStorage.
+let last = "";
+
+/** Collect the names of a document, and drop the whole entry when nothing is named. */
+export function saveNames(key: string, doc: Doc) {
+  const names: Names = {};
+  const walk = (ls: readonly Layer[], at: string) =>
+    ls.forEach((l, i) => {
+      const path = `${at}/${i}`;
+
+      if (l.name) names[path] = l.name;
+      walk(childrenOf(l), path);
+    });
+
+  doc.screens.forEach((s) => walk(s.layers, s.kind));
+  const seen = `${key}:${JSON.stringify(names)}`;
+
+  if (seen === last) return;
+  last = seen;
+  const store = all();
+
+  if (Object.keys(names).length) store[key] = names;
+  else delete store[key];
+  localStorage.setItem(STORE, JSON.stringify(store));
+}
+
+/** Put the stored names back on a freshly parsed document. */
+export function withNames(doc: Doc, key: string): Doc {
+  const names = all()[key];
+
+  if (!names) return doc;
+  const walk = (ls: readonly Layer[], at: string): Layer[] =>
+    ls.map((l, i) => {
+      const path = `${at}/${i}`;
+      const kids = childrenOf(l);
+      const next = kids.length ? withChildren(l, walk(kids, path)) : l;
+
+      return names[path] ? { ...next, name: names[path] } : next;
+    });
+
+  return { ...doc, screens: doc.screens.map((s) => ({ ...s, layers: walk(s.layers, s.kind) })) };
+}

--- a/src/lib/modules/editor/core/document/sources.ts
+++ b/src/lib/modules/editor/core/document/sources.ts
@@ -89,7 +89,7 @@ export const FRAME_LABELS: Record<number, string[]> = {
 // (0x5f byte 2), only ever seen in visibility conditions.
 export const sourceLabel = (id: number) =>
   ID_LABELS[id] ??
-  (id >= 0x79 && id <= 0x7e ? `slot ${id - 0x79} selection` : `id 0x${id.toString(16)}`);
+  (isSlotSel(id) ? `slot ${id - SLOT_SEL_ID} selection` : `id 0x${id.toString(16)}`);
 
 // The firmware exposes several aliases under one name — two `month`, two `battery`, four
 // `steps (slot)?`. Those are the only entries where the raw id is doing any work, so it's the

--- a/src/lib/modules/editor/core/format/raw.ts
+++ b/src/lib/modules/editor/core/format/raw.ts
@@ -67,6 +67,12 @@ export const TAG = {
   number: 0x60,
   group: 0x68,
   hand: 0x70,
+  /** Progress-ring spec, in two flavours: `arc` carries its own radius, `arcClipped` takes one
+   *  from the ring image it is clipped to. See core/render/arc.ts for the body. */
+  arc: 0x5a,
+  arcClipped: 0x5b,
+  /** A widget slot's body: index, the metrics it offers, and the active one. */
+  slot: 0x5f,
 } as const;
 
 // 0x0a/0x0e were swapped until this fix — confirmed by comparing hand geometry in

--- a/src/lib/modules/editor/core/import/facer/index.ts
+++ b/src/lib/modules/editor/core/import/facer/index.ts
@@ -16,7 +16,7 @@ import {
   tinted,
   unb64,
 } from "./assets";
-import { SCREEN } from "../../render/screen";
+import { PREVIEW, SCREEN } from "../../render/screen";
 import {
   classifyText,
   DIGITS,
@@ -562,7 +562,7 @@ export async function facerToFace(files: File[]): Promise<{ face: Face; skipped:
   async function screen(tag: number, sh: Sheet, pick: (f: Field) => boolean, ambient: boolean) {
     const subs: FaceNode[] = tag === TAG.main ? [{ tag: TAG.name, text: name }] : [];
 
-    subs.push(preview(await addRes(scaled(sh.base, 270, 270), 4)));
+    subs.push(preview(await addRes(scaled(sh.base, PREVIEW, PREVIEW), 4)));
     subs.push(imgWidget(0, 0, BG_META, await addRes(sh.base, 4)));
     for (const f of fields) if (pick(f)) subs.push(await buildField(f, ambient));
     for (const sel of sels.values())

--- a/src/lib/modules/editor/core/import/facer/index.ts
+++ b/src/lib/modules/editor/core/import/facer/index.ts
@@ -17,6 +17,7 @@ import {
   unb64,
 } from "./assets";
 import { PREVIEW, SCREEN } from "../../render/screen";
+import { encodeMeta, type WidgetMeta } from "../../document/doc";
 import {
   classifyText,
   DIGITS,
@@ -71,8 +72,21 @@ const handRole = (l: Layer): string | null => {
   return m ? (ROT[m[1]] ?? null) : null;
 };
 
-const META0 = "0000000000000000000000000000";
-const BG_META = "d201d20100000000000000000000"; // 466,466 LE + zeros
+// The 14 struct meta bytes: everything an imported widget leaves alone, and the full-screen
+// background, which is the same thing with the panel size in it.
+const ZERO_META: WidgetMeta = {
+  w: 0,
+  h: 0,
+  auto: false,
+  source: 0,
+  sub: 0,
+  max: 0,
+  rgb: [0, 0, 0],
+  flags: 0,
+  reserved: 0,
+};
+const META0 = encodeMeta(ZERO_META);
+const BG_META = encodeMeta({ ...ZERO_META, w: SCREEN, h: SCREEN });
 
 // Facer stores the same image under several hashes; round faces sometimes only
 // fill hash_square (or a cropped variant). Pick whichever is present.

--- a/src/lib/modules/editor/core/import/watchmaker.ts
+++ b/src/lib/modules/editor/core/import/watchmaker.ts
@@ -6,7 +6,7 @@
 // hour/minute/second/battery hands. Anything driven by a WatchMaker tag or a Lua expression
 // is skipped and reported.
 import { cropOpaque, encodeCanvas, fileMap } from "./facer/assets";
-import { SCREEN } from "../render/screen";
+import { PREVIEW, SCREEN } from "../render/screen";
 import { hex, TAG, type Face, type FaceNode, type Resource } from "../format";
 
 const W = SCREEN;
@@ -527,7 +527,7 @@ export async function watchmakerToFace(files: File[]): Promise<{ face: Face; ski
           tag: TAG.pvStruct,
           prefix: "0000000000",
           refType: 0x61,
-          images: [await addRes(scaled(sh.base, 270, 270), 4)],
+          images: [await addRes(scaled(sh.base, PREVIEW, PREVIEW), 4)],
         },
       ],
     });

--- a/src/lib/modules/editor/core/render/arc.ts
+++ b/src/lib/modules/editor/core/render/arc.ts
@@ -1,6 +1,6 @@
 // Progress rings: the 0x5a/0x5b arc spec that 0x80/0x81 widgets carry, and the two ways they
 // are drawn — a ring image clipped to a sector, or a stroked arc when there is no image.
-import { hex, unhex, type FaceNode } from "../format";
+import { hex, TAG, unhex, type FaceNode } from "../format";
 import { CENTER } from "./screen";
 import { goalOf, idValue, type Sim, type TimeParts } from "../document/sources";
 import type { Ctx, Drawable, Hit, Size } from "./canvas";
@@ -20,7 +20,7 @@ export interface ArcSpec {
 
 /** 0x5a/0x5b body: min i32 ‖ max i32 ‖ start i16 (0.1°) ‖ end i16 ‖ width u16 ‖ radius u16. */
 export function parseArcSpec(node: FaceNode): ArcSpec | null {
-  const sp = node.subs?.find((n) => n.tag === 0x5a || n.tag === 0x5b);
+  const sp = node.subs?.find((n) => n.tag === TAG.arc || n.tag === TAG.arcClipped);
 
   if (!sp) return null;
   const v = unhex(sp.hex || "");
@@ -40,16 +40,16 @@ export function parseArcSpec(node: FaceNode): ArcSpec | null {
     start: i16(8) / 10,
     end: i16(10) / 10,
     width: v[12] | (v[13] << 8),
-    radius: sp.tag === 0x5a && v.length >= 16 ? v[14] | (v[15] << 8) : 0,
+    radius: sp.tag === TAG.arc && v.length >= 16 ? v[14] | (v[15] << 8) : 0,
     // 0x5b never has its radius read, so its bytes 14.. are part of the tail
-    rest: hex(v.subarray(sp.tag === 0x5a ? 16 : 14)),
+    rest: hex(v.subarray(sp.tag === TAG.arc ? 16 : 14)),
   };
 }
 
 /** Inverse of parseArcSpec. The decoded head is 16 bytes for 0x5a and 14 for 0x5b (whose radius
  *  is never read), and `rest` carries whatever the file had past that. */
 export function arcSpecHex(spec: Omit<ArcSpec, "kind"> & { kind?: number }): string {
-  const head = spec.kind === 0x5b ? 14 : 16;
+  const head = spec.kind === TAG.arcClipped ? 14 : 16;
   const v = new Uint8Array(head);
   const put = (o: number, n: number, bytes: number) => {
     for (let i = 0; i < bytes; i++) v[o + i] = n >> (8 * i);

--- a/src/lib/modules/editor/model/edit.model.ts
+++ b/src/lib/modules/editor/model/edit.model.ts
@@ -76,11 +76,12 @@ export const aodAdded = createEvent();
 /** Drop it again — deleting the AOD root row in the tree. The main screen has no such option:
  *  a face without one has nothing to draw. */
 export const aodRemoved = createEvent();
-/** The editor-only per-layer flags. One event for both: they behave identically — a toggle over
- *  whatever is selected, or over one layer when the tree's own buttons fire it. */
+/** The editor-only per-layer fields. One event for all of them: they behave identically — a patch
+ *  over whatever is selected, or over one layer when the tree's own buttons fire it. `name` is a
+ *  label the tree shows instead of the derived one; like the flags it never reaches the file. */
 export const layerFlagsSet = createEvent<{
   ids: readonly NodeId[];
-  patch: { hidden?: boolean; locked?: boolean };
+  patch: { hidden?: boolean; locked?: boolean; name?: string };
 }>();
 export const duplicateRequested = createEvent();
 export const copyRequested = createEvent();

--- a/src/lib/modules/editor/model/io.model.ts
+++ b/src/lib/modules/editor/model/io.model.ts
@@ -1,9 +1,10 @@
 // Getting documents in and out: opening a .bin, starting a blank face, importing a Facer or
 // WatchMaker export, and building the bytes back. The assets are re-encoded on the way out only
 // (flushAssets), so everything the editor did to the pixels stays non-destructive until export.
-import { attach, createEffect, createEvent, sample } from "effector";
+import { attach, createEffect, createEvent, createStore, sample } from "effector";
 import { buildBin, parseBin } from "../core/format";
 import { fromLegacy, toLegacy, type Doc, type ImageId } from "../core/document/doc";
+import { saveNames, withNames } from "../core/document/names";
 import { blankDoc } from "../core/document/factory";
 import { decodeAssets, flushAssets, opaqueBlack, regenPreviewAssets } from "../core/render/pixels";
 import { renderDoc } from "../core/render/render";
@@ -15,7 +16,16 @@ import { $sim } from "./sim.model";
 import { errored } from "./ui.model";
 
 // ---- events ----
-export const loadRequested = createEvent<{ buf: ArrayBuffer | Uint8Array; label: string }>();
+/** `key` is the marketplace record the bytes came from — what the layer names are stored under.
+ *  A face with no record (New, a dropped .bin, an import) keeps its names for the session only. */
+export const loadRequested = createEvent<{
+  buf: ArrayBuffer | Uint8Array;
+  label: string;
+  key?: string;
+}>();
+/** Fired by the market model when the open face gains or loses its record — saving a draft mints
+ *  one, New/drag-drop detaches it. */
+export const faceKeySet = createEvent<string | null>();
 export const newFaceRequested = createEvent<string | void>();
 export const importFacerRequested = createEvent<File[]>();
 export const exportBin = createEvent();
@@ -23,14 +33,20 @@ export const exportBin = createEvent();
  *  subscribe, others ignore it. */
 export const loadDone = createEvent<{ doc: Doc; label: string }>();
 
+// ---- stores ----
+export const $faceKey = createStore<string | null>(null);
+
 // ---- effects ----
 const loadBufferFx = createEffect(
-  async ({ buf, label }: { buf: ArrayBuffer | Uint8Array; label: string }) => {
-    const { doc } = fromLegacy(parseBin(buf));
+  async ({ buf, label, key }: { buf: ArrayBuffer | Uint8Array; label: string; key?: string }) => {
+    const { doc: parsed } = fromLegacy(parseBin(buf));
+    const doc = key ? withNames(parsed, key) : parsed;
 
     return { doc, label, cache: await decodeAssets(doc.images) };
   },
 );
+
+const saveNamesFx = createEffect(({ key, doc }: { key: string; doc: Doc }) => saveNames(key, doc));
 
 export const $loading = loadBufferFx.pending;
 
@@ -147,6 +163,25 @@ const exportBinFx = attach({
 sample({
   clock: loadRequested,
   target: loadBufferFx,
+});
+sample({
+  clock: loadRequested,
+  fn: ({ key }) => key ?? null,
+  target: $faceKey,
+});
+sample({
+  clock: faceKeySet,
+  target: $faceKey,
+});
+// Every document change rewrites the name map — it is a handful of strings, and this way a rename
+// is stored whether it came from the tree, an undo or a paste. Without a record to key on there
+// is nowhere to put it, so the names stay in memory.
+sample({
+  clock: [$doc.updates, faceKeySet],
+  source: { key: $faceKey, doc: $doc },
+  filter: ({ key, doc }) => Boolean(key && doc),
+  fn: ({ key, doc }) => ({ key: key!, doc: doc! }),
+  target: saveNamesFx,
 });
 sample({
   clock: newFaceRequested,

--- a/src/lib/modules/editor/pages/editor.svelte
+++ b/src/lib/modules/editor/pages/editor.svelte
@@ -468,11 +468,11 @@
     ctx.beginPath();
     for (const x of guides.x) {
       ctx.moveTo(x + 0.5, 0);
-      ctx.lineTo(x + 0.5, 466);
+      ctx.lineTo(x + 0.5, SCREEN);
     }
     for (const y of guides.y) {
       ctx.moveTo(0, y + 0.5);
-      ctx.lineTo(466, y + 0.5);
+      ctx.lineTo(SCREEN, y + 0.5);
     }
     ctx.stroke();
     ctx.restore();

--- a/src/lib/modules/market/model/market.model.ts
+++ b/src/lib/modules/market/model/market.model.ts
@@ -145,7 +145,7 @@ sample({
 sample({
   clock: faceDetached,
   fn: () => null,
-  target: [$openedWf, $loadedWf],
+  target: [$openedWf, $loadedWf, editorModel.faceKeySet],
 });
 
 sample({
@@ -169,9 +169,10 @@ sample({
   fn: ({ wf }) => wf,
   target: $loadedWf,
 });
+// the record id doubles as the key the editor stores this face's layer names under
 sample({
   clock: openInEditorFx.doneData,
-  fn: ({ wf, buf }) => ({ buf, label: wf.name }),
+  fn: ({ wf, buf }) => ({ buf, label: wf.name, key: wf.id }),
   target: editorModel.loadRequested,
 });
 
@@ -199,6 +200,12 @@ sample({
 sample({
   clock: saveFx.doneData,
   target: $loadedWf,
+});
+// the first save mints the record — from here on the names have somewhere to live
+sample({
+  clock: saveFx.doneData,
+  fn: (wf) => wf.id,
+  target: editorModel.faceKeySet,
 });
 // Saving replaces the record's bin AND its preview file, so the cached catalog lists would
 // keep showing the old art (and old name) until a full page reload — $items is only fetched

--- a/tests/doc-edits.test.ts
+++ b/tests/doc-edits.test.ts
@@ -4,6 +4,7 @@
 import { test, expect } from "vitest";
 import { readFileSync } from "node:fs";
 import { parseBin, buildBin } from "../src/lib/modules/editor/core/format";
+import { SCREEN } from "../src/lib/modules/editor/core/render/screen";
 import {
   fromLegacy,
   toLegacy,
@@ -51,7 +52,7 @@ const emptyGroup = (): GroupLayer => ({
   tag: 0x68,
   kind: "group",
   conditions: [],
-  frame: { x: 0, y: 0, w: 466, h: 466, main: 0, track: 0, rest: "" },
+  frame: { x: 0, y: 0, w: SCREEN, h: SCREEN, main: 0, track: 0, rest: "" },
   children: [],
 });
 

--- a/tests/doc-factory.test.ts
+++ b/tests/doc-factory.test.ts
@@ -6,6 +6,7 @@ import { test, expect } from "vitest";
 import { buildBin, parseBin, TAG, type Resource } from "../src/lib/modules/editor/core/format";
 import { toLegacy } from "../src/lib/modules/editor/core/document/doc";
 import { blankDoc, withName } from "../src/lib/modules/editor/core/document/factory";
+import { SCREEN } from "../src/lib/modules/editor/core/render/screen";
 
 const res = (w: number, h: number): Resource => ({
   cf: 4,
@@ -15,13 +16,13 @@ const res = (w: number, h: number): Resource => ({
 });
 
 test("a blank document builds into a parseable file with both of its assets", () => {
-  const doc = blankDoc("Fresh", res(2, 2), res(466, 466));
+  const doc = blankDoc("Fresh", res(2, 2), res(SCREEN, SCREEN));
   const built = parseBin(buildBin(toLegacy(doc)));
 
   expect(built.name).toBe("Fresh");
   // the preview thumbnail and the background, in that order
   expect(built.resources).toHaveLength(2);
-  expect([built.resources[0].w, built.resources[1].w]).toEqual([2, 466]);
+  expect([built.resources[0].w, built.resources[1].w]).toEqual([2, SCREEN]);
   // one main screen carrying the name node, the embedded preview and the background
   expect(built.screens).toHaveLength(1);
   expect(built.screens[0].tag).toBe(TAG.main);
@@ -32,7 +33,10 @@ test("a blank document builds into a parseable file with both of its assets", ()
 // `name` keeps it whole — the trailing header byte means something we haven't figured out, so it
 // has to survive a rename untouched.
 test("renaming keeps the header's trailing byte and cuts only the header copy", () => {
-  const doc = withName(blankDoc("Fresh", res(2, 2), res(466, 466)), "A name well over fifteen");
+  const doc = withName(
+    blankDoc("Fresh", res(2, 2), res(SCREEN, SCREEN)),
+    "A name well over fifteen",
+  );
   const built = parseBin(buildBin(toLegacy(doc)));
 
   expect(doc.name).toBe("A name well over fifteen");

--- a/tests/editor-align.browser.test.ts
+++ b/tests/editor-align.browser.test.ts
@@ -13,6 +13,7 @@ import {
 } from "$lib/modules/editor/core/document/doc";
 import { patchLayer } from "$lib/modules/editor/core/document/edits";
 import { editorModel } from "$lib/modules/editor/model";
+import { SCREEN } from "$lib/modules/editor/core/render/screen";
 import url from "./__fixtures__/Analog__287__Simple_Dial.bin?url";
 import groupedUrl from "./__fixtures__/Multifunction__368__Function.bin?url";
 
@@ -35,7 +36,7 @@ const load = async (from: string, label: string) => {
 const canvas = () => {
   const c = document.createElement("canvas");
 
-  c.width = c.height = 466;
+  c.width = c.height = SCREEN;
   return c.getContext("2d")!;
 };
 
@@ -58,8 +59,8 @@ test("align lands the rendered bbox on center/bottom", async () => {
 
   const h = draw(ctx).findLast((x) => x.layer.id === h0.layer.id)!;
 
-  expect(h.x).toBe(Math.round((466 - h.w) / 2));
-  expect(h.y).toBe(466 - h.h);
+  expect(h.x).toBe(Math.round((SCREEN - h.w) / 2));
+  expect(h.y).toBe(SCREEN - h.h);
 });
 
 // A group frame's main-axis alignment is the flex alignment of the AUTO-laid-out children, not a

--- a/tests/editor-layer-flags.browser.test.ts
+++ b/tests/editor-layer-flags.browser.test.ts
@@ -7,6 +7,7 @@ import { renderDoc } from "$lib/modules/editor/core/render/render";
 import { findLayer } from "$lib/modules/editor/core/document/edits";
 import { framesOf, isPlaced, type NodeId } from "$lib/modules/editor/core/document/doc";
 import { editorModel } from "$lib/modules/editor/model";
+import { SCREEN } from "$lib/modules/editor/core/render/screen";
 import url from "./__fixtures__/Analog__287__Simple_Dial.bin?url";
 
 const doc = () => editorModel.$doc.getState()!;
@@ -29,7 +30,7 @@ const load = async (label: string) => {
 const draw = () => {
   const c = document.createElement("canvas");
 
-  c.width = c.height = 466;
+  c.width = c.height = SCREEN;
   return renderDoc(
     c.getContext("2d")!,
     doc(),

--- a/tests/editor-multi-select.browser.test.ts
+++ b/tests/editor-multi-select.browser.test.ts
@@ -10,6 +10,7 @@ import {
 } from "$lib/modules/editor/core/document/doc";
 import { findLayer } from "$lib/modules/editor/core/document/edits";
 import { editorModel } from "$lib/modules/editor/model";
+import { SCREEN } from "$lib/modules/editor/core/render/screen";
 import url from "./__fixtures__/Analog__287__Simple_Dial.bin?url";
 
 const doc = () => editorModel.$doc.getState()!;
@@ -34,7 +35,7 @@ const load = async (label: string) => {
 function boxOf(id: NodeId) {
   const c = document.createElement("canvas");
 
-  c.width = c.height = 466;
+  c.width = c.height = SCREEN;
   const hits = renderDoc(
     c.getContext("2d")!,
     doc(),

--- a/tests/editor-new-nodes.browser.test.ts
+++ b/tests/editor-new-nodes.browser.test.ts
@@ -15,6 +15,7 @@ import {
   type SlotLayer,
 } from "$lib/modules/editor/core/document/doc";
 import { editorModel } from "$lib/modules/editor/model";
+import { SCREEN } from "$lib/modules/editor/core/render/screen";
 import url from "./__fixtures__/Analog__287__Simple_Dial.bin?url";
 
 const doc = () => editorModel.$doc.getState()!;
@@ -42,7 +43,7 @@ const load = async (label: string) => {
 function boxOf(id: NodeId) {
   const c = document.createElement("canvas");
 
-  c.width = c.height = 466;
+  c.width = c.height = SCREEN;
   const hits = renderDoc(
     c.getContext("2d")!,
     doc(),
@@ -112,7 +113,7 @@ test("a widget slot is created with one icon per metric and a numbered 0x5f", as
 
   expect(written).toHaveLength(2);
   // the 0x5f body is a fixed width across the corpus
-  expect(unhex(written[0].subs!.find((n) => n.tag === 0x5f)!.hex!)).toHaveLength(33);
+  expect(unhex(written[0].subs!.find((n) => n.tag === TAG.slot)!.hex!)).toHaveLength(33);
 });
 
 test("dropping a widget into a group keeps it where it was, and ungroup puts it back", async () => {

--- a/tests/editor-preview-match.browser.test.ts
+++ b/tests/editor-preview-match.browser.test.ts
@@ -11,6 +11,7 @@ import { renderDoc } from "$lib/modules/editor/core/render/render";
 import { fromLegacy, framesOf } from "$lib/modules/editor/core/document/doc";
 import { defaultSim } from "$lib/modules/editor/core/document/sources";
 import { decodeAssets } from "$lib/modules/editor/core/render/pixels";
+import { SCREEN } from "$lib/modules/editor/core/render/screen";
 
 import analogUrl from "./__fixtures__/Analog__287__Simple_Dial.bin?url";
 import digitalUrl from "./__fixtures__/Digital__281__Metaball.bin?url";
@@ -213,8 +214,8 @@ describe("renderDoc() output matches embedded preview", () => {
 
       const canvas = document.createElement("canvas");
 
-      canvas.width = 466;
-      canvas.height = 466;
+      canvas.width = SCREEN;
+      canvas.height = SCREEN;
       const sim = {
         ...defaultSim(),
         live: false,

--- a/tests/editor-resize.browser.test.ts
+++ b/tests/editor-resize.browser.test.ts
@@ -12,6 +12,7 @@ import {
   type NodeId,
 } from "$lib/modules/editor/core/document/doc";
 import { editorModel } from "$lib/modules/editor/model";
+import { SCREEN } from "$lib/modules/editor/core/render/screen";
 import url from "./__fixtures__/Analog__287__Simple_Dial.bin?url";
 
 const doc = () => editorModel.$doc.getState()!;
@@ -36,7 +37,7 @@ async function load(label: string) {
 const draw = (preview?: ResizePreview) => {
   const c = document.createElement("canvas");
 
-  c.width = c.height = 466;
+  c.width = c.height = SCREEN;
   return renderDoc(
     c.getContext("2d")!,
     doc(),

--- a/tests/editor-slot-bind.browser.test.ts
+++ b/tests/editor-slot-bind.browser.test.ts
@@ -8,6 +8,7 @@ import { collectSlotsDoc, SLOT_SEL_ID } from "$lib/modules/editor/core/document/
 import { findLayer, slotBindingOf } from "$lib/modules/editor/core/document/edits";
 import { isPlaced, type NodeId } from "$lib/modules/editor/core/document/doc";
 import { editorModel } from "$lib/modules/editor/model";
+import { SCREEN } from "$lib/modules/editor/core/render/screen";
 import url from "./__fixtures__/Analog__287__Simple_Dial.bin?url";
 
 const doc = () => editorModel.$doc.getState()!;
@@ -17,7 +18,7 @@ const byId = (id: NodeId) => findLayer(doc(), id)!;
 const drawn = (id: NodeId) => {
   const c = document.createElement("canvas");
 
-  c.width = c.height = 466;
+  c.width = c.height = SCREEN;
   return renderDoc(
     c.getContext("2d")!,
     doc(),

--- a/tests/editor-slot-metrics.browser.test.ts
+++ b/tests/editor-slot-metrics.browser.test.ts
@@ -1,7 +1,7 @@
 // A slot's 0x5f list is the menu the companion app shows. Adding a metric needs an icon frame
 // beside it; removing one takes that frame with it, and the file has to stay valid either way.
 import { test, expect, vi } from "vitest";
-import { parseBin, unhex } from "$lib/modules/editor/core/format";
+import { TAG, parseBin, unhex } from "$lib/modules/editor/core/format";
 import { findLayer } from "$lib/modules/editor/core/document/edits";
 import { SLOT_METRIC_CHOICES } from "$lib/modules/editor/core/document/factory";
 import type { NodeId, SlotLayer } from "$lib/modules/editor/core/document/doc";
@@ -40,7 +40,7 @@ test("a metric can be added and removed, icon frame and all", async () => {
   // the 0x5f body must agree: [index][count][active][ids…]
   const built = parseBin(await editorModel.buildCurrentBin());
   const body = unhex(
-    built.screens[0].subs!.find((n) => n.tag === 0x85)!.subs!.find((n) => n.tag === 0x5f)!.hex!,
+    built.screens[0].subs!.find((n) => n.tag === 0x85)!.subs!.find((n) => n.tag === TAG.slot)!.hex!,
   );
 
   expect(body[1]).toBe(added.metrics.length);

--- a/tests/editor-snap.browser.test.ts
+++ b/tests/editor-snap.browser.test.ts
@@ -8,12 +8,13 @@ import { renderDoc } from "$lib/modules/editor/core/render/render";
 import { isPlaced } from "$lib/modules/editor/core/document/doc";
 import type { LayerHit } from "$lib/modules/editor/core/render/canvas";
 import { SNAP_THRESHOLD } from "$lib/modules/editor/shared/constants";
+import { SCREEN } from "$lib/modules/editor/core/render/screen";
 import url from "./__fixtures__/Analog__287__Simple_Dial.bin?url";
 
 const boxes = (): LayerHit[] => {
   const c = document.createElement("canvas");
 
-  c.width = c.height = 466;
+  c.width = c.height = SCREEN;
   return renderDoc(
     c.getContext("2d")!,
     editorModel.$doc.getState()!,
@@ -53,8 +54,8 @@ test("dragging a widget snaps its edge onto another widget's edge", async () => 
   expect(isPlaced(me.layer)).toBe(true);
 
   const r = canvas.getBoundingClientRect();
-  const k = r.width / 466; // canvas units -> client px
-  const tol = (SNAP_THRESHOLD * 466) / r.width;
+  const k = r.width / SCREEN; // canvas units -> client px
+  const tol = (SNAP_THRESHOLD * SCREEN) / r.width;
   const off = 3; // inside the snap window, so the drag must land flush instead
 
   expect(off).toBeLessThan(tol);
@@ -77,7 +78,7 @@ test("dragging a widget snaps its edge onto another widget's edge", async () => 
 
   // …and the guide is on screen while the pointer is still down
   await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
-  const px = canvas.getContext("2d")!.getImageData(Math.round(other.x), 0, 1, 466).data;
+  const px = canvas.getContext("2d")!.getImageData(Math.round(other.x), 0, 1, SCREEN).data;
   // magenta-ish rather than exactly GUIDE_COLOR: the guide is drawn over the face and may carry
   // alpha, so what identifies it is red+blue far above green
   let magenta = false;

--- a/tests/editor-snap.test.ts
+++ b/tests/editor-snap.test.ts
@@ -3,6 +3,7 @@
 import { describe, test, expect } from "vitest";
 import { snapAxis, snapTargets } from "$lib/modules/editor/core/render/snap";
 import { SNAP_THRESHOLD } from "$lib/modules/editor/shared/constants";
+import { CENTER, SCREEN } from "$lib/modules/editor/core/render/screen";
 import type { LayerHit } from "$lib/modules/editor/core/render/canvas";
 import type { GroupLayer, Layer, NodeId } from "$lib/modules/editor/core/document/doc";
 
@@ -58,7 +59,7 @@ describe("snapTargets", () => {
       [dragged],
     );
 
-    expect(t.xs).toEqual([0, 233, 466, 200, 230, 260]);
-    expect(t.ys).toEqual([0, 233, 466, 300, 320, 340]);
+    expect(t.xs).toEqual([0, CENTER, SCREEN, 200, 230, 260]);
+    expect(t.ys).toEqual([0, CENTER, SCREEN, 300, 320, 340]);
   });
 });

--- a/tests/facer-import.browser.test.ts
+++ b/tests/facer-import.browser.test.ts
@@ -5,6 +5,10 @@ import { test, expect } from "vitest";
 import { facerToFace } from "$lib/modules/editor/core/import/facer";
 import { TAG, decodePixels, unhex, type FaceNode } from "$lib/modules/editor/core/format";
 import { metaInfo } from "$lib/modules/editor/core/document/sources";
+import { CENTER, SCREEN } from "$lib/modules/editor/core/render/screen";
+
+/** Facer authors against its own canvas; the fixture uses the default one. */
+const FACER_CANVAS = 320;
 
 const LAYERS = [
   { type: "shape", shape_type: 1, x: 0, y: 0, width: 320, height: 320, color: -16777216 },
@@ -213,13 +217,13 @@ test("facerToFace maps tags, hands and alignment", async () => {
   expect(asc(hands.map(idOf))).toEqual([0x0a, 0x0e, 0x12]);
 
   // ...and are cropped to their ink: a full-canvas 466×466 cf 5 hand costs 650 KB of RAM on
-  // the watch and reboots it. x + pivot must still land on the layer centre (160 scaled by
-  // 466/320 = 233), otherwise the hand rotates around the wrong point.
+  // the watch and reboots it. x + pivot must still land on the layer centre (Facer's own 160,
+  // scaled from its 320 canvas to ours), otherwise the hand rotates around the wrong point.
   const hst = hands[0].subs!.find((s) => s.tag === TAG.struct)!;
   const hres = face.resources[hst.images![0]];
 
-  expect(hres.w).toBeLessThan(Math.round((100 * 466) / 320));
-  expect(hst.x! + hands[0].subs!.find((s) => s.tag === TAG.pivot)!.pivotX!).toBe(233);
+  expect(hres.w).toBeLessThan(Math.round((100 * SCREEN) / FACER_CANVAS));
+  expect(hst.x! + hands[0].subs!.find((s) => s.tag === TAG.pivot)!.pivotX!).toBe(CENTER);
 
   // conditional opacity can't be expressed on the watch, so that layer is dropped, not baked
   expect(all(main, (n) => n.tag === TAG.number).some((n) => idOf(n) === 0x1a)).toBe(false);
@@ -229,7 +233,7 @@ test("facerToFace maps tags, hands and alignment", async () => {
   expect(all(aod, (n) => n.tag === TAG.number).map(idOf)).toEqual([0x19]);
 
   // a full-screen JPEG (cf 1) background reboots the watch when it leaves AOD — cf 4 only
-  const bgs = face.resources.filter((r) => r.w === 466 && r.h === 466);
+  const bgs = face.resources.filter((r) => r.w === SCREEN && r.h === SCREEN);
 
   expect(bgs).toHaveLength(2); // one per screen
   expect(bgs.map((r) => r.cf)).toEqual([4, 4]);

--- a/tests/layer-names.browser.test.ts
+++ b/tests/layer-names.browser.test.ts
@@ -7,9 +7,10 @@ import type { Resource } from "../src/lib/modules/editor/core/format";
 import { patchLayer } from "../src/lib/modules/editor/core/document/edits";
 import { blankDoc } from "../src/lib/modules/editor/core/document/factory";
 import { saveNames, withNames } from "../src/lib/modules/editor/core/document/names";
+import { PREVIEW, SCREEN } from "../src/lib/modules/editor/core/render/screen";
 
 const res = (w: number, h: number): Resource => ({ cf: 4, w, h, data: new Uint8Array(w * h * 2) });
-const fresh = () => blankDoc("Fresh", res(2, 2), res(466, 466));
+const fresh = () => blankDoc("Fresh", res(PREVIEW, PREVIEW), res(SCREEN, SCREEN));
 
 test("names come back on a document reparsed from the same record", () => {
   const doc = fresh();

--- a/tests/layer-names.browser.test.ts
+++ b/tests/layer-names.browser.test.ts
@@ -1,0 +1,36 @@
+// Layer names never reach the .bin — they are stored beside it, keyed by the marketplace record
+// and by the layer's position in the tree. This pins the round trip, which is the whole feature:
+// what saveNames writes, withNames has to put back on a document parsed from scratch.
+// Browser test for localStorage alone.
+import { test, expect } from "vitest";
+import type { Resource } from "../src/lib/modules/editor/core/format";
+import { patchLayer } from "../src/lib/modules/editor/core/document/edits";
+import { blankDoc } from "../src/lib/modules/editor/core/document/factory";
+import { saveNames, withNames } from "../src/lib/modules/editor/core/document/names";
+
+const res = (w: number, h: number): Resource => ({ cf: 4, w, h, data: new Uint8Array(w * h * 2) });
+const fresh = () => blankDoc("Fresh", res(2, 2), res(466, 466));
+
+test("names come back on a document reparsed from the same record", () => {
+  const doc = fresh();
+  const bg = doc.screens[0].layers.at(-1)!;
+  const named = patchLayer(doc, bg.id, { name: "Фон" });
+
+  saveNames("rec1", named);
+  // fresh() mints new NodeIds, exactly like reopening the file does
+  const back = withNames(fresh(), "rec1");
+
+  expect(back.screens[0].layers.at(-1)!.name).toBe("Фон");
+  // another record's names are none of this face's business
+  expect(withNames(fresh(), "otherRecord").screens[0].layers.some((l) => l.name)).toBe(false);
+});
+
+test("clearing the last name drops the record's entry", () => {
+  const doc = fresh();
+  const bg = doc.screens[0].layers.at(-1)!;
+
+  saveNames("rec2", patchLayer(doc, bg.id, { name: "Фон" }));
+  saveNames("rec2", patchLayer(doc, bg.id, { name: undefined }));
+  expect(withNames(fresh(), "rec2").screens[0].layers.at(-1)!.name).toBeUndefined();
+  expect(localStorage.getItem("fmc_layer_names")).not.toContain("rec2");
+});

--- a/tests/render-doc.browser.test.ts
+++ b/tests/render-doc.browser.test.ts
@@ -8,6 +8,7 @@ import { renderDoc } from "$lib/modules/editor/core/render/render";
 import { decodeAssets } from "$lib/modules/editor/core/render/pixels";
 import { fromLegacy } from "$lib/modules/editor/core/document/doc";
 import { defaultSim } from "$lib/modules/editor/core/document/sources";
+import { SCREEN } from "$lib/modules/editor/core/render/screen";
 
 const FIXTURES = import.meta.glob("./__fixtures__/*.bin", {
   query: "?url",
@@ -25,11 +26,12 @@ const sim = () => ({
 function canvas() {
   const c = document.createElement("canvas");
 
-  c.width = c.height = 466;
+  c.width = c.height = SCREEN;
   return c;
 }
 
-const pixels = (c: HTMLCanvasElement) => c.getContext("2d")!.getImageData(0, 0, 466, 466).data;
+const pixels = (c: HTMLCanvasElement) =>
+  c.getContext("2d")!.getImageData(0, 0, SCREEN, SCREEN).data;
 
 const docOf = async (url: string) => {
   const { doc } = fromLegacy(parseBin(await fetch(url).then((r) => r.arrayBuffer())));

--- a/tests/watchmaker-import.browser.test.ts
+++ b/tests/watchmaker-import.browser.test.ts
@@ -6,6 +6,7 @@ import { test, expect } from "vitest";
 import { watchmakerToFace } from "$lib/modules/editor/core/import/watchmaker";
 import { TAG, type FaceNode } from "$lib/modules/editor/core/format";
 import { metaInfo } from "$lib/modules/editor/core/document/sources";
+import { CENTER, SCREEN } from "$lib/modules/editor/core/render/screen";
 
 const LAYERS = `
  <Layer type="shape" x="0" y="0" width="512" height="512" shape="Circle" color="000000" opacity="100" display="bd"/>
@@ -52,7 +53,7 @@ test("watchmakerToFace decodes the export and maps hands, screens and skips", as
   expect(aod.tag).toBe(TAG.aod);
   expect(face.name).toBe("Probe Face");
   // a full-screen JPEG (cf 1) background reboots the watch when it leaves AOD — cf 4 only
-  const bgs = face.resources.filter((r) => r.w === 466 && r.h === 466);
+  const bgs = face.resources.filter((r) => r.w === SCREEN && r.h === SCREEN);
 
   expect(bgs).toHaveLength(2); // one per screen
   expect(bgs.map((r) => r.cf)).toEqual([4, 4]);
@@ -64,13 +65,13 @@ test("watchmakerToFace decodes the export and maps hands, screens and skips", as
   expect(hands.map(idOf)).toEqual([0x0a, 0x0e, 0x12]);
   expect(hands.map((h) => structOf(h)._kind)).toEqual(["hour", "minute", "second"]);
 
-  // every hand rotates about the dial centre (466 / 2 = 233), wherever its crop landed
+  // every hand rotates about the dial centre, wherever its crop landed
   for (const h of hands) {
     const st = structOf(h);
     const pv = h.subs!.find((s) => s.tag === TAG.pivot)!;
 
-    expect(Math.abs(st.x! + pv.pivotX! - 233)).toBeLessThanOrEqual(1);
-    expect(Math.abs(st.y! + pv.pivotY! - 233)).toBeLessThanOrEqual(1);
+    expect(Math.abs(st.x! + pv.pivotX! - CENTER)).toBeLessThanOrEqual(1);
+    expect(Math.abs(st.y! + pv.pivotY! - CENTER)).toBeLessThanOrEqual(1);
   }
 
   // display="b" keeps the second hand off the AOD; display="d" is what the battery hand is for


### PR DESCRIPTION
Closes #9.

The issue asked for two things; manual grouping already existed (the Add menu's **Group**, and **Group** over a selection), so this PR is the renaming half.

### What changed

- **Rename in the layer tree.** Double-click a row — or pick **Rename** from its context / "…" menu — and the row swaps for an input. Enter or blur commits, Escape cancels, an empty value falls back to the derived label (`Image · Battery`, etc.). Rows render `l.name || layerLabel(l)`.
- **It's an ordinary layer patch.** `LayerBase.name` already existed and was unused; the rename goes through `layerFlagsSet`, so it behaves like hide/lock and lands in undo history.
- **Names survive a reload for faces that have a record.** The format has no string node for a layer, so nothing can ride along in the `.bin`. `core/document/names.ts` stores them in `localStorage` under `fmc_layer_names`, keyed by the marketplace record id the face was opened from — reopening the same watchface from `/my` brings its names back.

### The tradeoff worth reviewing

A layer is addressed by its **position in the tree** (`main/3/1`), not by `NodeId` — ids are minted fresh on every parse and mean nothing across sessions. So inserting or deleting a sibling shifts the names below it; renaming again fixes it. The upgrade path (key on something the layer carries: kind + coordinates + frame ids) is written down in the file's header comment.

A face with no record (New, a dropped `.bin`, a Facer/WatchMaker import) has nothing stable to key on, so its names stay in the session.

`saveNames` memoizes the serialized map, because the model calls it on every document change — during a drag that's once per frame, and only an actual rename reaches `localStorage`.

### Tests

`npm run check` clean, `npm test` 135 passing, including a new `tests/layer-names.browser.test.ts`: save a name, "reopen" the document with fresh NodeIds, the name comes back; another record's names don't leak in; clearing the last name drops the entry.

Manually verified in the editor: created a group, renamed it, ⌘Z restored the derived label, ⌘⇧Z brought the name back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UAhR6P6u5xbE7KQmmWYZDf