### PR TITLE
Keyboard-first editor: one shortcut table, a ? overlay, and menus that show their keys

### DIFF
--- a/src/lib/modules/editor/components/ShortcutsDialog.svelte
+++ b/src/lib/modules/editor/components/ShortcutsDialog.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+  // The `?` overlay. Rendered straight off the keymap table, so a binding that exists is
+  // documented and one that doesn't, isn't.
+  import { Dialog } from "$lib/shared/components/dialog";
+  import { formatKeys, isMac, shortcutGroups } from "../shared/shortcuts";
+
+  interface Props {
+    open: boolean;
+    onClose: () => void;
+  }
+  const { open, onClose }: Props = $props();
+
+  const mac = isMac();
+  const groups = shortcutGroups();
+</script>
+
+<Dialog {open} {onClose} title="Keyboard shortcuts">
+  <div class="groups">
+    {#each groups as g (g.group)}
+      <section>
+        <h3>{g.group}</h3>
+        {#each g.items as s (s.keys)}
+          <div class="row">
+            <span class="label">{s.label}</span>
+            <span class="keys">
+              {#each formatKeys(s.keys, mac) as k (k)}<kbd>{k}</kbd>{/each}
+            </span>
+          </div>
+        {/each}
+      </section>
+    {/each}
+  </div>
+</Dialog>
+
+<style>
+  .groups {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+  h3 {
+    margin: 0 0 0.375rem;
+    font-size: 0.625rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: oklch(from var(--color-text) l c h / 55%);
+  }
+  .row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.25rem 0;
+    font-size: 0.75rem;
+  }
+  .label {
+    color: oklch(from var(--color-text) l c h / 80%);
+  }
+  .keys {
+    display: flex;
+    flex: none;
+    gap: 0.1875rem;
+  }
+  kbd {
+    padding: 0.125rem 0.375rem;
+    font-family: var(--font-mono);
+    font-size: 0.625rem;
+    line-height: 1.4;
+    border: 1px solid oklch(from var(--color-text) l c h / 12%);
+    border-radius: calc(var(--border-radius) / 2);
+    background: oklch(from var(--color-text) l c h / 6%);
+  }
+</style>

--- a/src/lib/modules/editor/components/TreePanel.svelte
+++ b/src/lib/modules/editor/components/TreePanel.svelte
@@ -7,6 +7,7 @@
   import { pickerLabel, describeConditions } from "../core/document/sources";
   import { contains, parentOf } from "../core/document/edits";
   import { framesOf, type Layer, type NodeId, type Screen } from "../core/document/doc";
+  import { capsFor } from "../shared/shortcuts";
   import { editorModel } from "../model";
   const {
     $doc: doc,
@@ -311,17 +312,17 @@
 />
 
 {#snippet layerActions()}
-  <MenuItem onClick={duplicateRequested}>
+  <MenuItem keys={capsFor("mod+d")} onClick={duplicateRequested}>
     <Icon name="copy" size={14} /> Duplicate
   </MenuItem>
-  <MenuItem onClick={copyRequested}>
+  <MenuItem keys={capsFor("mod+c")} onClick={copyRequested}>
     <Icon name="clipboard" size={14} /> Copy
   </MenuItem>
-  <MenuItem onClick={cutRequested}>
+  <MenuItem keys={capsFor("mod+x")} onClick={cutRequested}>
     <Icon name="scissors" size={14} /> Cut
   </MenuItem>
   {#if $clipboard}
-    <MenuItem onClick={pasteRequested}>
+    <MenuItem keys={capsFor("mod+v")} onClick={pasteRequested}>
       <Icon name="clipboard-check" size={14} /> Paste
     </MenuItem>
   {/if}
@@ -342,7 +343,7 @@
     <Icon name={$selected[0]?.locked ? "lock-open" : "lock"} size={14} />
     {$selected[0]?.locked ? "Unlock" : "Lock"}
   </MenuItem>
-  <MenuItem danger onClick={deleteRequested}>
+  <MenuItem danger keys={capsFor("delete")} onClick={deleteRequested}>
     <Icon name="trash" size={14} /> Delete
   </MenuItem>
 {/snippet}

--- a/src/lib/modules/editor/core/document/edits.ts
+++ b/src/lib/modules/editor/core/document/edits.ts
@@ -64,6 +64,15 @@ export function parentOf(doc: Doc, id: NodeId): Layer | null {
   return null;
 }
 
+/** The row `id` sits in — its group's children, or the screen's own layer list. Empty when the
+ *  document doesn't hold it. */
+export function siblingsOf(doc: Doc, id: NodeId): readonly Layer[] {
+  const parent = parentOf(doc, id);
+
+  if (parent) return childrenOf(parent);
+  return doc.screens.find((s) => s.layers.some((l) => l.id === id))?.layers ?? [];
+}
+
 export const contains = (l: Layer, id: NodeId): boolean =>
   l.id === id || childrenOf(l).some((c) => contains(c, id));
 
@@ -151,14 +160,12 @@ export const originOf = (l: Layer): { x: number; y: number } =>
       ? { x: l.x, y: l.y }
       : { x: 0, y: 0 };
 
-/** Move a layer by a delta. Group frames stay clamped to >=0 — their x/y is unsigned in the file,
- *  unlike a widget's int16 x/y, which may legitimately hang off the left/top edge. */
+/** Move a layer by a delta. Nothing is clamped: a group's frame x/y is int16 in the file, same as
+ *  a widget's, so hanging off the left or top edge round-trips (see the 0x48 frame in doc.ts —
+ *  it is read with i16 and written back as two's complement). */
 export const shiftLayer = (l: Layer, dx: number, dy: number): Layer =>
   l.kind === "group"
-    ? {
-        ...l,
-        frame: { ...l.frame, x: Math.max(0, l.frame.x + dx), y: Math.max(0, l.frame.y + dy) },
-      }
+    ? { ...l, frame: { ...l.frame, x: l.frame.x + dx, y: l.frame.y + dy } }
     : isPlaced(l)
       ? { ...l, x: l.x + dx, y: l.y + dy }
       : l;

--- a/src/lib/modules/editor/model/edit.model.ts
+++ b/src/lib/modules/editor/model/edit.model.ts
@@ -19,6 +19,7 @@ import {
   repointFrames,
   setSlotBinding,
   shiftLayer,
+  siblingsOf,
   ungroup,
   wrapInGroup,
 } from "../core/document/edits";
@@ -94,6 +95,9 @@ export const moveRequested = createEvent<{
   after: boolean;
   into?: boolean;
 }>();
+/** ⌘] / ⌘[ — one step up or down the draw order, among the primary selection's own siblings.
+ *  `moveRequested` is the tree's drag-and-drop, which needs an explicit target; this doesn't. */
+export const orderMoved = createEvent<1 | -1>();
 export const conditionToggled = createEvent<NodeId>();
 export const slotBindSet = createEvent<{ id: NodeId; slot: number | null; metric?: number }>();
 /** The metrics a slot offers the wearer — its own 0x5f list, which the companion app shows as a
@@ -671,6 +675,24 @@ sample({
       return l
         ? patchLayer(moved, id, shiftLayer(l, a.x - b.x, a.y - b.y) as Partial<Layer>)
         : moved;
+    },
+  }),
+  target: committed,
+});
+
+// One step along the row, staying inside the same container. At either end there is nowhere to
+// go and the edit hands the document straight back, so `committed` drops it and no undo is spent.
+sample({
+  clock: orderMoved,
+  source: $sel,
+  filter: Boolean,
+  fn: (id, dir) => ({
+    edit: (d: Doc) => {
+      const row = siblingsOf(d, id);
+      const i = row.findIndex((l) => l.id === id);
+      const j = i + dir;
+
+      return i < 0 || j < 0 || j >= row.length ? d : moveLayer(d, id, row[j].id, dir > 0);
     },
   }),
   target: committed,

--- a/src/lib/modules/editor/model/selection.model.ts
+++ b/src/lib/modules/editor/model/selection.model.ts
@@ -2,8 +2,8 @@
 // object: the document is immutable, so every edit hands back fresh layer objects and a stored
 // reference would go stale on the next keystroke.
 import { combine, createEvent, createStore, sample } from "effector";
-import { findLayer } from "../core/document/edits";
-import type { Layer, NodeId, Screen } from "../core/document/doc";
+import { findLayer, parentOf, siblingsOf } from "../core/document/edits";
+import type { Doc, Layer, NodeId, Screen } from "../core/document/doc";
 import { $doc } from "./doc.model";
 import { $rightPanel } from "./ui.model";
 
@@ -26,6 +26,17 @@ export const selectToggled = createEvent<NodeId>(); // ctrl/cmd/shift-click: add
 export const screenSet = createEvent<Screen["kind"]>();
 /** The whole selection at once, primary first — the one place $sel and $more are written. */
 export const selectionSet = createEvent<readonly NodeId[]>();
+/** ⌘A — every top-level layer of the screen being edited. Group children come along with their
+ *  group, the way selecting a group already behaves everywhere else. */
+export const selectAllRequested = createEvent();
+/** Keyboard navigation: the next (+1) or previous (-1) sibling of the primary selection. */
+export const siblingSelected = createEvent<1 | -1>();
+/** Step into a group (+1 — its first child) or out to the parent (-1). */
+export const nestSelected = createEvent<1 | -1>();
+
+// ---- helpers ----
+const layersOf = (doc: Doc, kind: Screen["kind"]): readonly Layer[] =>
+  doc.screens.find((s) => s.kind === kind)?.layers ?? [];
 
 // ---- business logic ----
 sample({
@@ -57,6 +68,40 @@ sample({
 sample({
   clock: screenSet,
   target: $screen,
+});
+sample({
+  clock: selectAllRequested,
+  source: { doc: $doc, screen: $screen },
+  filter: ({ doc }) => Boolean(doc),
+  fn: ({ doc, screen }) => layersOf(doc!, screen).map((l) => l.id),
+  target: selectionSet,
+});
+// Sibling and nesting steps collapse a multi-selection down to the one layer they land on —
+// that is what makes them useful for walking a tree with the keyboard.
+sample({
+  clock: siblingSelected,
+  source: { doc: $doc, sel: $sel },
+  filter: ({ doc, sel }) => Boolean(doc && sel),
+  fn: ({ doc, sel }, dir) => {
+    const row = siblingsOf(doc!, sel!);
+    const i = row.findIndex((l) => l.id === sel);
+
+    // wraps: a row of two is faster to walk round than to reverse direction on
+    return i < 0 ? sel : row[(i + dir + row.length) % row.length].id;
+  },
+  target: select,
+});
+sample({
+  clock: nestSelected,
+  source: { doc: $doc, sel: $sel },
+  filter: ({ doc, sel }) => Boolean(doc && sel),
+  fn: ({ doc, sel }, dir) => {
+    if (dir < 0) return parentOf(doc!, sel!)?.id ?? sel;
+    const l = findLayer(doc!, sel!);
+
+    return l?.kind === "group" ? (l.children[0]?.id ?? sel) : sel;
+  },
+  target: select,
 });
 // opening a layer's properties is what the user means by clicking it
 sample({

--- a/src/lib/modules/editor/pages/editor.svelte
+++ b/src/lib/modules/editor/pages/editor.svelte
@@ -14,10 +14,12 @@
   import { containerOrigin, findLayer, parentOf } from "../core/document/edits";
   import { snapAxis, snapTargets, type SnapTargets } from "../core/render/snap";
   import { SNAP_THRESHOLD, GUIDE_WIDTH, GUIDE_COLOR } from "../shared/constants";
+  import { inField, isRoving, matchShortcut, type ShortcutActions } from "../shared/shortcuts";
   import { editorModel } from "../model";
   import TreePanel from "../components/TreePanel.svelte";
   import PropsPanel from "../components/PropsPanel.svelte";
   import SimPanel from "../components/SimPanel.svelte";
+  import ShortcutsDialog from "../components/ShortcutsDialog.svelte";
 
   const { $user: user } = authModel;
   const {
@@ -46,6 +48,9 @@
     $redoN: redoN,
     select,
     selectToggled,
+    selectAllRequested,
+    siblingSelected,
+    nestSelected,
     screenSet,
     checkpoint,
     undo,
@@ -55,7 +60,9 @@
     copyRequested,
     cutRequested,
     pasteRequested,
+    duplicateRequested,
     deleteRequested,
+    orderMoved,
     resizeImageRequested,
     resizeGroupRequested,
     $lockAspect: lockAspect,
@@ -75,6 +82,7 @@
   let canvas = $state<HTMLCanvasElement | null>(null);
 
   let mobilePanel = $state<"tree" | "props" | "sim" | null>(null); // drawer on mobile
+  let helpOpen = $state(false); // the `?` overlay
   let hits: LayerHit[] = [];
 
   // ---- resizable side panels (desktop only — below 768px both are drawers) ----
@@ -125,6 +133,7 @@
 
     if (!step) return;
     e.preventDefault();
+    e.stopPropagation(); // the window handler would also read this as "move the selection"
     setSide(side, (side === "tree" ? treeW : rightW) + (side === "tree" ? step : -step));
   }
 
@@ -500,13 +509,14 @@
     return l.kind === "raw" ? null : { layer: l, x0: l.x, y0: l.y };
   }
 
-  // widget x/y are int16 — negatives are legal (and used by stock faces), so no clamp there;
-  // group frames stay >=0, their x/y round-trip through the file as unsigned
+  // No clamp on either kind: x/y is int16 for a widget and for a group's frame alike, so a layer
+  // may hang off the left or top edge — stock faces do it, and the inspector has always let you
+  // type it. See shiftLayer, which is the same move by a delta.
   const moveItem = (it: DragItem, x: number, y: number) =>
     layerPatched({
       id: it.layer.id,
       patch: (it.layer.kind === "group"
-        ? { frame: { ...it.layer.frame, x: Math.max(0, x), y: Math.max(0, y) } }
+        ? { frame: { ...it.layer.frame, x, y } }
         : { x, y }) as Partial<Layer>,
     });
 
@@ -646,42 +656,80 @@
     guides = { x: [], y: [] };
   }
 
-  function onKey(e: KeyboardEvent) {
-    if (["INPUT", "TEXTAREA", "SELECT"].includes((e.target as HTMLElement).tagName)) return;
-    if (e.metaKey || e.ctrlKey) {
-      const k = e.key.toLowerCase();
-
-      if (k === "z") (e.shiftKey ? redo : undo)();
-      else if (k === "c") copyRequested();
-      else if (k === "x") cutRequested();
-      else if (k === "v") pasteRequested();
-      else return;
-      e.preventDefault();
-      return;
-    }
-    if (!$selected.length) return;
-    if (e.key === "Backspace" || e.key === "Delete") {
-      deleteRequested();
-      e.preventDefault();
-      return;
-    }
-    const d = e.shiftKey ? 10 : 1;
-    const moves: Record<string, [number, number]> = {
-      ArrowLeft: [-d, 0],
-      ArrowRight: [d, 0],
-      ArrowUp: [0, -d],
-      ArrowDown: [0, d],
-    };
-    const mv = moves[e.key];
-
-    if (!mv) return;
+  // ---- keyboard ----
+  // The whole keymap lives in shared/shortcuts.ts; this file only says what each action means.
+  function nudgeMove(dx: number, dy: number) {
     checkpoint();
     for (const l of $selected) {
       const it = dragItem(l);
 
-      if (it) moveItem(it, it.x0 + mv[0], it.y0 + mv[1]);
+      if (it) moveItem(it, it.x0 + dx, it.y0 + dy);
     }
+  }
+
+  // The keyboard twin of applyResize: the box grows from its top-left, so unlike a corner drag
+  // there is no anchor to correct for and the layer's x/y are left alone.
+  // ponytail: the primary selection only — resizing N layers by 1px each needs N async rescales
+  // and a way to keep them in one undo step. Nobody has asked for it yet.
+  function nudgeResize(dw: number, dh: number) {
+    const l = $selected[0];
+
+    if (!resizable(l)) return;
+    const b = boxOf(l.id);
+
+    if (!b || b.w < 1 || b.h < 1) return;
+    const kw = Math.max(1, b.w + dw) / b.w,
+      kh = Math.max(1, b.h + dh) / b.h;
+
+    if (l.kind === "group") {
+      resizeGroupRequested({ layer: l.id, kw, kh });
+      return;
+    }
+    const r0 = firstAsset(l);
+
+    if (!r0) return;
+    resizeImageRequested({
+      layer: l.id,
+      w: Math.max(1, Math.round(r0.w * kw)),
+      h: Math.max(1, Math.round(r0.h * kh)),
+    });
+  }
+
+  const actions: ShortcutActions = {
+    undo: () => undo(),
+    redo: () => redo(),
+    copy: () => copyRequested(),
+    cut: () => cutRequested(),
+    paste: () => pasteRequested(),
+    duplicate: () => duplicateRequested(),
+    remove: () => deleteRequested(),
+    order: (dir) => orderMoved(dir),
+    clearSelection: () => select(null),
+    selectAll: () => selectAllRequested(),
+    sibling: (dir) => siblingSelected(dir),
+    nest: (dir) => nestSelected(dir),
+    move: nudgeMove,
+    resize: nudgeResize,
+    save: () => void saveDraft(),
+    exportBin: () => exportBin(),
+    flash: () => void flashWatch(),
+    panel: (tab) => rightPanelSet(tab),
+    // picking AOD with no AOD screen creates one — the same thing the tab does
+    screen: (kind) => (kind === "aod" && !hasAOD ? aodAdded() : screenSet(kind)),
+    help: () => (helpOpen = true),
+  };
+
+  function onKey(e: KeyboardEvent) {
+    const hit = matchShortcut(e, {
+      doc: Boolean($doc),
+      selection: $selected.length > 0,
+      field: inField(e.target),
+      roving: isRoving(e.target),
+    });
+
+    if (!hit) return;
     e.preventDefault();
+    hit.run(actions, e);
   }
 
   async function flashWatch() {
@@ -862,7 +910,8 @@
       {/if}
       <p class="hint">
         click — select · drag / arrow keys (⇧ ×10) — move · ⌥ drag — no snap · corners — resize (⇧
-        inverts the aspect lock) · ⌘Z undo
+        inverts the aspect lock) ·
+        <button class="hint-key" onclick={() => (helpOpen = true)}>? — all shortcuts</button>
       </p>
     </section>
 
@@ -934,6 +983,8 @@
 </Dialog>
 
 <PublishDialog />
+
+<ShortcutsDialog open={helpOpen} onClose={() => (helpOpen = false)} />
 
 <style>
   .page {
@@ -1147,6 +1198,19 @@
     text-align: center;
     font-size: 0.625rem;
     color: oklch(from var(--color-text) l c h / 55%);
+  }
+  /* the hint itself ignores the pointer so it can't shadow the canvas — the one clickable word
+     in it has to opt back in */
+  .hint-key {
+    padding: 0;
+    border: none;
+    background: none;
+    font: inherit;
+    color: inherit;
+    cursor: pointer;
+    pointer-events: auto;
+    text-decoration: underline dotted;
+    text-underline-offset: 0.125rem;
   }
   @media (min-width: 768px) {
     .hint {

--- a/src/lib/modules/editor/shared/shortcuts.ts
+++ b/src/lib/modules/editor/shared/shortcuts.ts
@@ -1,0 +1,418 @@
+// The editor keymap: one table, matched against a keydown and rendered into the help overlay.
+// Nothing here imports Svelte or the model — an entry names an action on the `ShortcutActions`
+// bag the page hands in, so the same table is both the binding list and the documentation and
+// the two can't drift apart.
+//
+// A combo is written mod+alt+shift+key, in that order. `mod` is ⌘ on a Mac and Ctrl elsewhere —
+// the two are never told apart, so a Mac user with an external PC keyboard gets both.
+
+/** The bits of a KeyboardEvent the matcher reads — spelled out so tests can pass a literal. */
+export type KeyLike = Pick<
+  KeyboardEvent,
+  "key" | "code" | "metaKey" | "ctrlKey" | "altKey" | "shiftKey"
+>;
+
+/** What the page can do. Every entry's `run` reaches for exactly one of these. */
+export interface ShortcutActions {
+  undo(): void;
+  redo(): void;
+  copy(): void;
+  cut(): void;
+  paste(): void;
+  duplicate(): void;
+  remove(): void;
+  /** Draw order among siblings: +1 towards the front, -1 towards the back. */
+  order(dir: 1 | -1): void;
+  clearSelection(): void;
+  selectAll(): void;
+  /** Move the selection to the next (+1) or previous (-1) sibling. */
+  sibling(dir: 1 | -1): void;
+  /** Step into a group (+1, its first child) or out to the parent (-1). */
+  nest(dir: 1 | -1): void;
+  move(dx: number, dy: number): void;
+  resize(dw: number, dh: number): void;
+  save(): void;
+  exportBin(): void;
+  flash(): void;
+  panel(tab: "props" | "sim"): void;
+  screen(kind: "main" | "aod"): void;
+  help(): void;
+}
+
+/** What decides whether a binding applies right now. */
+export interface ShortcutCtx {
+  /** A document is open. */
+  readonly doc: boolean;
+  /** At least one layer is selected. */
+  readonly selection: boolean;
+  /** Focus sits in a text field or inside a dialog — nothing fires there. */
+  readonly field: boolean;
+  /** Focus is on the page itself rather than on a control. Tab and Enter are the browser's while
+   *  a button has focus — stealing them there would break keyboard navigation of the toolbar. */
+  readonly roving: boolean;
+}
+
+export interface Shortcut {
+  /** Every combo that runs this action. */
+  readonly combos: readonly string[];
+  /** How the keys are written in the overlay: `+`-separated tokens, `Mod`/`Shift`/`Alt` are
+   *  swapped for the platform's symbols by `formatKeys`. */
+  readonly keys: string;
+  readonly label: string;
+  readonly group: string;
+  readonly when?: (ctx: ShortcutCtx) => boolean;
+  readonly run: (a: ShortcutActions, e: KeyLike) => void;
+}
+
+// ---- key naming ----
+const NAMED: Record<string, string> = {
+  Escape: "esc",
+  Delete: "delete",
+  Backspace: "backspace",
+  Enter: "enter",
+  Tab: "tab",
+  ArrowLeft: "left",
+  ArrowRight: "right",
+  ArrowUp: "up",
+  ArrowDown: "down",
+};
+
+/** The combo a keydown stands for, e.g. `mod+shift+e`.
+ *
+ *  Letters and digits are read off `e.code`, not `e.key`: on a non-Latin layout ⌘C reports a
+ *  Cyrillic `с`, and matching on that would leave half the keymap dead for anyone not typing in
+ *  English. Everything else — the named keys and `?` — goes by `e.key`, which is layout-correct
+ *  by definition (`?` is shift+/ on one layout and shift+7 on another). */
+export function comboOf(e: KeyLike): string {
+  const base =
+    e.key === "?"
+      ? "?"
+      : /^Key[A-Z]$/.test(e.code)
+        ? e.code.slice(3).toLowerCase()
+        : /^Digit\d$/.test(e.code)
+          ? e.code.slice(5)
+          : e.code === "BracketLeft"
+            ? "["
+            : e.code === "BracketRight"
+              ? "]"
+              : (NAMED[e.key] ?? e.key.toLowerCase());
+  // `?` already carries its shift — listing it would make the combo unwritable
+  if (base === "?") return "?";
+  const mods = [];
+
+  if (e.metaKey || e.ctrlKey) mods.push("mod");
+  if (e.altKey) mods.push("alt");
+  if (e.shiftKey) mods.push("shift");
+  return [...mods, base].join("+");
+}
+
+/** Does focus sit somewhere that owns the keyboard? Takes the event target rather than an
+ *  element so a test can hand it a bare `{ tagName }`. */
+export function inField(target: EventTarget | null): boolean {
+  const el = target as (HTMLElement & { closest?: (s: string) => unknown }) | null;
+
+  if (!el?.tagName) return false;
+  if (["INPUT", "TEXTAREA", "SELECT"].includes(el.tagName)) return true;
+  if (el.isContentEditable) return true;
+  return Boolean(el.closest?.("dialog"));
+}
+
+/** Is focus on the page rather than on a control of its own? Same duck-typing as `inField`. */
+export const isRoving = (target: EventTarget | null): boolean => {
+  const el = target as (HTMLElement & { matches?: (s: string) => boolean }) | null;
+
+  if (!el?.tagName || el.tagName === "CANVAS") return true;
+  return !el.matches?.("a[href], button, [tabindex], [role]");
+};
+
+const step = (e: KeyLike) => (e.shiftKey ? 10 : 1);
+/** The direction an arrow key points, scaled by ⇧. */
+const arrow = (e: KeyLike): [number, number] => {
+  const d = step(e);
+
+  switch (NAMED[e.key]) {
+    case "left":
+      return [-d, 0];
+    case "right":
+      return [d, 0];
+    case "up":
+      return [0, -d];
+    default:
+      return [0, d];
+  }
+};
+const ARROWS = ["left", "right", "up", "down"];
+const withShift = (combos: string[]) => [...combos, ...combos.map((c) => `shift+${c}`)];
+const hasDoc = (c: ShortcutCtx) => c.doc;
+const hasSel = (c: ShortcutCtx) => c.selection;
+// Tab and Enter belong to whatever control has focus — take them only on the page itself
+const roving = (c: ShortcutCtx) => c.selection && c.roving;
+
+export const SHORTCUTS: readonly Shortcut[] = [
+  // ---- File ----
+  {
+    combos: ["mod+s"],
+    keys: "Mod+S",
+    label: "Save the watchface",
+    group: "File",
+    when: hasDoc,
+    run: (a) => a.save(),
+  },
+  {
+    combos: ["mod+e"],
+    keys: "Mod+E",
+    label: "Export .bin",
+    group: "File",
+    when: hasDoc,
+    run: (a) => a.exportBin(),
+  },
+  {
+    combos: ["mod+shift+e"],
+    keys: "Mod+Shift+E",
+    label: "Flash to the watch",
+    group: "File",
+    when: hasDoc,
+    run: (a) => a.flash(),
+  },
+
+  // ---- Edit ----
+  {
+    combos: ["mod+z"],
+    keys: "Mod+Z",
+    label: "Undo",
+    group: "Edit",
+    run: (a) => a.undo(),
+  },
+  {
+    combos: ["mod+shift+z"],
+    keys: "Mod+Shift+Z",
+    label: "Redo",
+    group: "Edit",
+    run: (a) => a.redo(),
+  },
+  {
+    combos: ["mod+c"],
+    keys: "Mod+C",
+    label: "Copy",
+    group: "Edit",
+    when: hasSel,
+    run: (a) => a.copy(),
+  },
+  {
+    combos: ["mod+x"],
+    keys: "Mod+X",
+    label: "Cut",
+    group: "Edit",
+    when: hasSel,
+    run: (a) => a.cut(),
+  },
+  {
+    combos: ["mod+v"],
+    keys: "Mod+V",
+    label: "Paste",
+    group: "Edit",
+    when: hasDoc,
+    run: (a) => a.paste(),
+  },
+  {
+    combos: ["mod+d"],
+    keys: "Mod+D",
+    label: "Duplicate",
+    group: "Edit",
+    when: hasSel,
+    run: (a) => a.duplicate(),
+  },
+  {
+    combos: ["delete", "backspace"],
+    keys: "Delete / Backspace",
+    label: "Delete the selection",
+    group: "Edit",
+    when: hasSel,
+    run: (a) => a.remove(),
+  },
+  {
+    combos: ["mod+]"],
+    keys: "Mod+]",
+    label: "Bring forward",
+    group: "Edit",
+    when: hasSel,
+    run: (a) => a.order(1),
+  },
+  {
+    combos: ["mod+["],
+    keys: "Mod+[",
+    label: "Send backward",
+    group: "Edit",
+    when: hasSel,
+    run: (a) => a.order(-1),
+  },
+
+  // ---- Selection ----
+  {
+    combos: ["esc"],
+    keys: "Esc",
+    label: "Clear the selection",
+    group: "Selection",
+    when: hasSel,
+    run: (a) => a.clearSelection(),
+  },
+  {
+    combos: ["mod+a"],
+    keys: "Mod+A",
+    label: "Select everything on this screen",
+    group: "Selection",
+    when: hasDoc,
+    run: (a) => a.selectAll(),
+  },
+  {
+    combos: ["mod+shift+a"],
+    keys: "Mod+Shift+A",
+    label: "Deselect",
+    group: "Selection",
+    when: hasDoc,
+    run: (a) => a.clearSelection(),
+  },
+  {
+    combos: ["tab"],
+    keys: "Tab",
+    label: "Next sibling layer",
+    group: "Selection",
+    when: roving,
+    run: (a) => a.sibling(1),
+  },
+  {
+    combos: ["shift+tab"],
+    keys: "Shift+Tab",
+    label: "Previous sibling layer",
+    group: "Selection",
+    when: roving,
+    run: (a) => a.sibling(-1),
+  },
+  {
+    combos: ["enter"],
+    keys: "Enter",
+    label: "Enter the group",
+    group: "Selection",
+    when: roving,
+    run: (a) => a.nest(1),
+  },
+  {
+    combos: ["shift+enter"],
+    keys: "Shift+Enter",
+    label: "Step out to the parent",
+    group: "Selection",
+    when: roving,
+    run: (a) => a.nest(-1),
+  },
+
+  // ---- Layout ----
+  {
+    combos: withShift(ARROWS),
+    keys: "←/→/↑/↓",
+    label: "Move by 1px (⇧ — 10px)",
+    group: "Layout",
+    when: hasSel,
+    run: (a, e) => a.move(...arrow(e)),
+  },
+  {
+    combos: withShift(ARROWS.map((k) => `alt+${k}`)),
+    keys: "Alt+←/→/↑/↓",
+    label: "Resize by 1px (⇧ — 10px)",
+    group: "Layout",
+    when: hasSel,
+    run: (a, e) => a.resize(...arrow(e)),
+  },
+
+  // ---- View ----
+  {
+    combos: ["1"],
+    keys: "1",
+    label: "Properties tab",
+    group: "View",
+    run: (a) => a.panel("props"),
+  },
+  {
+    combos: ["2"],
+    keys: "2",
+    label: "Simulator tab",
+    group: "View",
+    when: hasDoc,
+    run: (a) => a.panel("sim"),
+  },
+  {
+    combos: ["m"],
+    keys: "M",
+    label: "Main screen",
+    group: "View",
+    when: hasDoc,
+    run: (a) => a.screen("main"),
+  },
+  {
+    combos: ["a"],
+    keys: "A",
+    label: "AOD screen",
+    group: "View",
+    when: hasDoc,
+    run: (a) => a.screen("aod"),
+  },
+  {
+    combos: ["?"],
+    keys: "?",
+    label: "This list",
+    group: "View",
+    run: (a) => a.help(),
+  },
+];
+
+/** The binding a keydown fires, or null. Nothing fires while a field or dialog has focus. */
+export function matchShortcut(e: KeyLike, ctx: ShortcutCtx): Shortcut | null {
+  if (ctx.field) return null;
+  const combo = comboOf(e);
+
+  return SHORTCUTS.find((s) => s.combos.includes(combo) && (s.when?.(ctx) ?? true)) ?? null;
+}
+
+/** `Mod+Shift+E` -> the keycaps to draw, in this platform's alphabet. */
+export const formatKeys = (keys: string, mac: boolean): string[] =>
+  keys
+    .split("+")
+    .map((k) =>
+      k === "Mod"
+        ? mac
+          ? "⌘"
+          : "Ctrl"
+        : k === "Shift"
+          ? mac
+            ? "⇧"
+            : "Shift"
+          : k === "Alt"
+            ? mac
+              ? "⌥"
+              : "Alt"
+            : k,
+    );
+
+export const isMac = () => /Mac|iPhone|iPad/.test(globalThis.navigator?.userAgent ?? "");
+
+/** The keycaps bound to `combo`, ready to draw next to a menu entry — empty when nothing is
+ *  bound, so a menu can ask about any action without checking first. Where an entry lists
+ *  alternatives (`Delete / Backspace`) only the first is shown: a menu has room for one. */
+export const capsFor = (combo: string): string[] => {
+  const s = SHORTCUTS.find((x) => x.combos.includes(combo));
+
+  return s ? formatKeys(s.keys.split(" / ")[0], isMac()) : [];
+};
+
+/** The table as the overlay shows it: groups in table order, entries within them too. */
+export const shortcutGroups = (): { group: string; items: readonly Shortcut[] }[] => {
+  const out: { group: string; items: Shortcut[] }[] = [];
+
+  for (const s of SHORTCUTS) {
+    const bucket =
+      out.find((g) => g.group === s.group) ??
+      (out.push({ group: s.group, items: [] }), out[out.length - 1]);
+
+    bucket.items.push(s);
+  }
+  return out;
+};

--- a/src/lib/shared/components/menu/menu-item.svelte
+++ b/src/lib/shared/components/menu/menu-item.svelte
@@ -2,14 +2,22 @@
   import type { Snippet } from "svelte";
   interface Props {
     danger?: boolean;
+    /** Keycaps for the shortcut that runs the same action, already in the platform's alphabet.
+     *  The caller owns the keymap — this only draws what it is handed. */
+    keys?: readonly string[];
     onClick?: () => void;
     children?: Snippet;
   }
-  const { danger, onClick, children }: Props = $props();
+  const { danger, keys, onClick, children }: Props = $props();
 </script>
 
 <button class="item" class:danger role="menuitem" onclick={onClick}>
   {@render children?.()}
+  {#if keys?.length}
+    <span class="keys"
+      >{#each keys as k (k)}<kbd>{k}</kbd>{/each}</span
+    >
+  {/if}
 </button>
 
 <style>
@@ -33,5 +41,18 @@
   }
   .danger {
     color: var(--color-error);
+  }
+  /* pushed to the far edge, and it never squeezes the label */
+  .keys {
+    display: flex;
+    flex: none;
+    gap: 0.125rem;
+    margin-inline-start: auto;
+    padding-inline-start: 1rem;
+  }
+  kbd {
+    font-family: var(--font-mono);
+    font-size: 0.625rem;
+    color: oklch(from var(--color-text) l c h / 55%);
   }
 </style>

--- a/tests/doc-edits.test.ts
+++ b/tests/doc-edits.test.ts
@@ -22,6 +22,7 @@ import {
   patchLayer,
   removeLayer,
   setSlotBinding,
+  shiftLayer,
   slotBindingOf,
   ungroup,
   usedAssets,
@@ -174,4 +175,22 @@ test("dropping a layer drops its assets from the file, not from other users of t
 
   expect(slotsLeft).toBe(1);
   expect(after).toBe(before);
+});
+
+// The canvas drag used to clamp a group's frame to >=0 on the theory that it is unsigned in the
+// file, which left the inspector able to type a coordinate the mouse could not reach. It isn't:
+// the 0x48 frame is read with i16 and written back as two's complement, same as a widget's x/y.
+test("a group dragged off the top-left corner keeps its negative frame through the file", () => {
+  const doc = load();
+  const group = flatten(doc).find((l) => l.kind === "group") as GroupLayer;
+  const moved = patchLayer(
+    doc,
+    group.id,
+    shiftLayer(group, -200 - group.frame.x, -37) as Partial<Layer>,
+  );
+  const at = flatten(moved).findIndex((l) => l.id === group.id);
+  // ids are handed out fresh on every parse, so the round-tripped layer is found by position
+  const back = flatten(fromLegacy(parseBin(buildBin(toLegacy(moved)))).doc)[at] as GroupLayer;
+
+  expect(back.frame).toMatchObject({ x: -200, y: group.frame.y - 37 });
 });

--- a/tests/editor-keyboard-nav.browser.test.ts
+++ b/tests/editor-keyboard-nav.browser.test.ts
@@ -1,0 +1,88 @@
+// What the keyboard-only bindings do to the model: select-all, walking siblings, stepping in and
+// out of a group, and nudging the draw order. The keymap itself is covered by editor-shortcuts.
+import { test, expect } from "vitest";
+import type { GroupLayer, NodeId } from "$lib/modules/editor/core/document/doc";
+import { findLayer } from "$lib/modules/editor/core/document/edits";
+import { editorModel } from "$lib/modules/editor/model";
+import url from "./__fixtures__/Analog__287__Simple_Dial.bin?url";
+
+const doc = () => editorModel.$doc.getState()!;
+const layers = () => doc().screens[0].layers;
+const sel = () => editorModel.$sel.getState();
+const byId = (id: NodeId) => findLayer(doc(), id)!;
+
+const load = async (label: string) => {
+  const buf = await fetch(url).then((r) => r.arrayBuffer());
+
+  await new Promise<void>((resolve) => {
+    const unwatch = editorModel.loadDone.watch(() => {
+      unwatch();
+      resolve();
+    });
+
+    editorModel.loadRequested({ buf, label });
+  });
+};
+
+test("select-all takes every top-level layer of the open screen", async () => {
+  await load("kbd-all");
+  editorModel.selectAllRequested();
+  expect(editorModel.$selected.getState().map((l) => l.id)).toEqual(layers().map((l) => l.id));
+});
+
+test("Tab walks the siblings and wraps at the ends", async () => {
+  await load("kbd-tab");
+  const row = layers();
+
+  editorModel.select(row[0].id);
+  editorModel.siblingSelected(1);
+  expect(sel()).toBe(row[1].id);
+
+  editorModel.siblingSelected(-1);
+  editorModel.siblingSelected(-1);
+  expect(sel()).toBe(row.at(-1)!.id); // wrapped past the front
+
+  editorModel.siblingSelected(1);
+  expect(sel()).toBe(row[0].id);
+});
+
+test("Enter steps into a group and ⇧Enter back out", async () => {
+  await load("kbd-nest");
+  const first = layers()[0].id;
+
+  editorModel.select(first);
+  editorModel.groupRequested();
+  const groupId = sel()!;
+
+  editorModel.nestSelected(1);
+  expect(sel()).toBe((byId(groupId) as GroupLayer).children[0].id);
+  editorModel.nestSelected(-1);
+  expect(sel()).toBe(groupId);
+  editorModel.nestSelected(-1); // already at the top — nowhere to go
+  expect(sel()).toBe(groupId);
+});
+
+test("⌘] / ⌘[ move one step along the row, and the ends cost no undo", async () => {
+  await load("kbd-order");
+  const row = layers();
+  const [a, b] = [row[0].id, row[1].id];
+
+  editorModel.select(a);
+  editorModel.orderMoved(1);
+  expect(
+    layers()
+      .map((l) => l.id)
+      .slice(0, 2),
+  ).toEqual([b, a]);
+  editorModel.orderMoved(-1);
+  expect(
+    layers()
+      .map((l) => l.id)
+      .slice(0, 2),
+  ).toEqual([a, b]);
+
+  const undos = editorModel.$undoN.getState();
+
+  editorModel.orderMoved(-1); // already first
+  expect(editorModel.$undoN.getState()).toBe(undos);
+});

--- a/tests/editor-shortcuts.test.ts
+++ b/tests/editor-shortcuts.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  SHORTCUTS,
+  capsFor,
+  comboOf,
+  formatKeys,
+  inField,
+  isMac,
+  isRoving,
+  matchShortcut,
+  shortcutGroups,
+  type KeyLike,
+  type ShortcutActions,
+  type ShortcutCtx,
+} from "../src/lib/modules/editor/shared/shortcuts";
+
+const key = (over: Partial<KeyLike> & { key: string }): KeyLike => ({
+  code: "",
+  metaKey: false,
+  ctrlKey: false,
+  altKey: false,
+  shiftKey: false,
+  ...over,
+});
+const CTX: ShortcutCtx = { doc: true, selection: true, field: false, roving: true };
+const ctx = (over: Partial<ShortcutCtx> = {}): ShortcutCtx => ({ ...CTX, ...over });
+
+/** Every action stubbed, so a `run` can be watched without the editor around it. */
+const actions = () =>
+  new Proxy({} as ShortcutActions & Record<string, ReturnType<typeof vi.fn>>, {
+    get: (t, k: string) => (t[k] ??= vi.fn()),
+  });
+
+describe("comboOf", () => {
+  it("names modifiers in a fixed order, ⌘ and Ctrl alike", () => {
+    expect(comboOf(key({ key: "e", code: "KeyE", metaKey: true }))).toBe("mod+e");
+    expect(comboOf(key({ key: "e", code: "KeyE", ctrlKey: true }))).toBe("mod+e");
+    expect(comboOf(key({ key: "E", code: "KeyE", metaKey: true, shiftKey: true }))).toBe(
+      "mod+shift+e",
+    );
+    expect(
+      comboOf(key({ key: "ArrowLeft", code: "ArrowLeft", altKey: true, shiftKey: true })),
+    ).toBe("alt+shift+left");
+  });
+
+  it("reads letters and digits off the physical key, not the layout", () => {
+    // ⌘C on a Cyrillic layout: e.key is `с`, the key under the finger is still KeyC
+    expect(comboOf(key({ key: "с", code: "KeyC", metaKey: true }))).toBe("mod+c");
+    expect(comboOf(key({ key: "ц", code: "KeyW" }))).toBe("w");
+    expect(comboOf(key({ key: "1", code: "Digit1" }))).toBe("1");
+    expect(comboOf(key({ key: "]", code: "BracketRight", metaKey: true }))).toBe("mod+]");
+  });
+
+  it("takes ? by character — it is shift+/ on one layout and shift+7 on another", () => {
+    expect(comboOf(key({ key: "?", code: "Slash", shiftKey: true }))).toBe("?");
+    expect(comboOf(key({ key: "?", code: "Digit7", shiftKey: true }))).toBe("?");
+  });
+});
+
+describe("matchShortcut", () => {
+  it("runs the action a combo is bound to", () => {
+    const a = actions();
+
+    matchShortcut(key({ key: "d", code: "KeyD", metaKey: true }), CTX)?.run(a, key({ key: "d" }));
+    expect(a.duplicate).toHaveBeenCalled();
+  });
+
+  it("scales an arrow by ⇧ and resizes with ⌥", () => {
+    const a = actions();
+    const down = key({ key: "ArrowDown", code: "ArrowDown", shiftKey: true });
+    const wide = key({ key: "ArrowRight", code: "ArrowRight", altKey: true });
+
+    matchShortcut(down, CTX)?.run(a, down);
+    matchShortcut(wide, CTX)?.run(a, wide);
+    expect(a.move).toHaveBeenCalledWith(0, 10);
+    expect(a.resize).toHaveBeenCalledWith(1, 0);
+  });
+
+  it("keeps ⌘⇧A and ⌘A apart", () => {
+    expect(matchShortcut(key({ key: "a", code: "KeyA", metaKey: true }), CTX)?.label).toMatch(
+      /Select everything/,
+    );
+    expect(
+      matchShortcut(key({ key: "a", code: "KeyA", metaKey: true, shiftKey: true }), CTX)?.label,
+    ).toBe("Deselect");
+  });
+
+  it("fires nothing while a field or a dialog has focus", () => {
+    expect(matchShortcut(key({ key: "Delete", code: "Delete" }), ctx({ field: true }))).toBeNull();
+    expect(inField({ tagName: "INPUT" } as unknown as EventTarget)).toBe(true);
+    expect(inField({ tagName: "DIV", closest: () => ({}) } as unknown as EventTarget)).toBe(true);
+    expect(inField({ tagName: "DIV", closest: () => null } as unknown as EventTarget)).toBe(false);
+    expect(inField(null)).toBe(false);
+  });
+
+  it("honours the context an entry asks for", () => {
+    const del = key({ key: "Delete", code: "Delete" });
+
+    expect(matchShortcut(del, CTX)).not.toBeNull();
+    expect(matchShortcut(del, ctx({ selection: false }))).toBeNull();
+    // undo has no `when` — it works on an empty selection
+    expect(
+      matchShortcut(key({ key: "z", code: "KeyZ", metaKey: true }), ctx({ doc: false })),
+    ).not.toBeNull();
+    // the AOD screen needs a document to put one on
+    expect(matchShortcut(key({ key: "a", code: "KeyA" }), ctx({ doc: false }))).toBeNull();
+  });
+
+  it("leaves Tab and Enter to whatever control has focus", () => {
+    const tab = key({ key: "Tab", code: "Tab" });
+
+    expect(matchShortcut(tab, CTX)?.label).toMatch(/Next sibling/);
+    expect(matchShortcut(tab, ctx({ roving: false }))).toBeNull();
+    expect(isRoving({ tagName: "CANVAS" } as unknown as EventTarget)).toBe(true);
+    expect(isRoving({ tagName: "BUTTON", matches: () => true } as unknown as EventTarget)).toBe(
+      false,
+    );
+  });
+});
+
+describe("the table itself", () => {
+  it("binds every combo exactly once", () => {
+    const all = SHORTCUTS.flatMap((s) => s.combos);
+
+    expect(new Set(all).size).toBe(all.length);
+  });
+
+  // ShortcutsDialog renders shortcutGroups() and nothing else, so this is the documented list
+  it("documents every binding in the overlay", () => {
+    expect(shortcutGroups().flatMap((g) => g.items)).toEqual([...SHORTCUTS]);
+  });
+
+  it("writes the modifiers in this platform's alphabet", () => {
+    expect(formatKeys("Mod+Shift+E", true)).toEqual(["⌘", "⇧", "E"]);
+    expect(formatKeys("Mod+Shift+E", false)).toEqual(["Ctrl", "Shift", "E"]);
+  });
+
+  it("hands a menu the keycaps for an action, or nothing", () => {
+    expect(capsFor("mod+d")).toEqual([isMac() ? "⌘" : "Ctrl", "D"]);
+    expect(capsFor("delete")).toEqual(["Delete"]); // one alternative is all a menu has room for
+    expect(capsFor("mod+g")).toEqual([]); // grouping isn't bound
+  });
+});


### PR DESCRIPTION
Closes #6 (Phase 1, plus the cheap parts of Phases 2–3).

## What's here

The editor had three bindings; everything else was a toolbar click. The keymap
now lives in `editor/shared/shortcuts.ts` as a plain table — combos, a `when`
predicate, and a `run` naming one action on a bag the page hands in — and
`editor.svelte`'s handler is a single `matchShortcut`. The `?` overlay renders
that same table, so the documented list can't drift from the real bindings.

New on top of undo/copy/cut/paste/delete/arrows:

| Keys | Action |
|---|---|
| `Esc` | clear the selection |
| `⌘D` | duplicate |
| `⌘S` / `⌘E` / `⌘⇧E` | save · export `.bin` · flash to the watch |
| `⌘A` / `⌘⇧A` | select everything on the screen · deselect |
| `⌘[` / `⌘]` | draw order among siblings |
| `Tab` / `⇧Tab` | previous / next sibling |
| `Enter` / `⇧Enter` | enter a group · step out to the parent |
| `1` / `2`, `M` / `A` | Properties / Simulator tab, Main / AOD screen |
| `⌥` + arrows | resize by 1px (`⇧` — 10px) |
| `?` | the overlay |

Model side: `selectAllRequested`, `siblingSelected`, `nestSelected` in
selection.model, `orderMoved` in edit.model, and `siblingsOf` moved into edits.ts
so both use one definition.

Context-menu and `…`-menu entries now show their shortcut on the right, read out
of the same table by `capsFor` — `MenuItem` gained a `keys` prop and draws what
it is handed, so the shared component stays clear of the editor's keymap.

## Two decisions worth naming

- **Letters and digits match on `e.code`, not `e.key`.** On a Cyrillic layout ⌘C
  reports `с`; matching on that leaves half the keymap dead for anyone not typing
  in English. Named keys and `?` still go by `e.key`, which is layout-correct by
  definition.
- **Tab and Enter are only taken when focus is on the page itself** (`roving` in
  the context). Stealing them from a focused button would break keyboard
  navigation of the toolbar. `gutterKey` now stops propagation for the same
  reason — arrows on the panel separator were both resizing the panel and moving
  the selection.

Windows keycaps come from the platform (`⌘⇧⌥` on a Mac, `Ctrl`/`Shift`/`Alt`
elsewhere), which is [what was asked for in the issue thread](https://github.com/freethinkel/fmc/issues/6#issuecomment-5093838893).

## Drive-by fix: the clamp that outlived its reason

Dragging a **group** clamped its frame to `>=0`, on the stated theory that a
group's x/y is unsigned in the file. It isn't — the 0x48 frame is read with `i16`
(`doc.ts`) and written back as two's complement — so the inspector could type a
coordinate the mouse could not reach. That's why "some watchfaces won't let me
drag past 0": the ones built with groups. Clamp removed from `moveItem` and
`shiftLayer`, with a round-trip test pinning a group at x `-200` through
`buildBin`/`parseBin`.

⚠️ Untested on hardware: what the watch itself does with a negative group frame
is unknown. The file format round-trips it and the editor draws it correctly.

## Verification

`npm test` — 35 files, 151 tests. `npm run check` — 0 errors. `oxlint`, `oxfmt`,
`npm run build` clean. Also driven for real in a browser: the `?` overlay opens
and lists all 26 bindings, the context menu shows its keycaps, console clean.

New tests: `tests/editor-shortcuts.test.ts` (matcher — layout, modifiers, `when`
context, overlay/table identity) and `tests/editor-keyboard-nav.browser.test.ts`
(select-all, sibling wrap, nesting, order nudge including "the ends cost no
undo").

## Not in this PR

The invasive half of Phase 2/3 from #6: marquee selection on empty canvas,
range-select in the tree, and `Mixed` fields in PropsPanel for a multi-selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01APYXFoGE7DV37pbbXhLFgc
