### PR TITLE
Number widget: generate the digit set from a font

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,11 @@ and `frames` sections; `PropsPanel.svelte` is the container and owns the shared 
 - **All logic lives in effector models** (`modules/*/model/*.model.ts`). Components are
   view only: `import { editorModel } from '../model'`, destructure stores/events at the
   top, subscribe via `$store`. Don't put business logic or data loading in components.
+  A component's own `$state` is for view-local, throwaway things only — an element ref, a
+  drag in progress, which row is hovered. Anything an action reads (form fields, a
+  computed preview, a list fetched or derived from somewhere) belongs in a store, even if
+  only one component uses it: a dialog with more than a couple of fields gets its own
+  `<feature>.model.ts` rather than a pile of `$state` (see `font-sprite.model.ts`).
 - Domain types: `Doc`, `Layer`, `Screen`, `ImageAsset`, `NodeId`/`ImageId` — in
   `core/document/doc.ts`; `Sim` — in `core/document/sources.ts`; `LayerHit`, `ImageStore` — in
   `core/render/canvas.ts`; `Face`/`FaceNode`/`Resource` — in `core/format/raw.ts` (file shape only).
@@ -98,7 +103,8 @@ and `frames` sections; `PropsPanel.svelte` is the container and owns the shared 
   so components keep importing a single `editorModel`:
   `doc.model` (the `Doc` + history), `selection.model` (`$sel`/`$more`/`$screen`, by `NodeId`),
   `sim.model`, `ui.model` (panel tab, last error), `assets.model` (assets + the bitmap cache),
-  `edit.model` (every action on the layer tree), `io.model` (open/create/import/export).
+  `edit.model` (every action on the layer tree), `io.model` (open/create/import/export),
+  `font-sprite.model` (the "sprites from a font" generator: dialog, form, preview).
 - **The document is immutable.** Every edit is a pure `Doc -> Doc` function from
   `core/document/edits.ts`, handed to `committed` — which checkpoints and applies in one step, and
   skips both when the edit returns the document unchanged (a rejected move must not eat an undo).

--- a/src/lib/modules/auth/components/login-form.svelte
+++ b/src/lib/modules/auth/components/login-form.svelte
@@ -43,7 +43,7 @@
   {#if $err}
     <p class="error">{$err}</p>
   {/if}
-  <Button size="large" type="submit" kind="primary" disabled={$busy}>Login</Button>
+  <Button type="submit" kind="primary" disabled={$busy}>Login</Button>
   <p class="link">Don't have an account? <a href="/register">Sign up</a></p>
 </form>
 

--- a/src/lib/modules/editor/components/GlyphsDialog.svelte
+++ b/src/lib/modules/editor/components/GlyphsDialog.svelte
@@ -1,0 +1,295 @@
+<script lang="ts">
+  // Regenerate the selected widget's sprites from a font instead of hand-made PNGs: the ten
+  // digits of a number, the labels of a value-indexed set. Everything here is preview — the
+  // sprites that end up in the document are rasterized again in glyphsFx, off the same pure
+  // functions, so what you see is what gets encoded.
+  import { Dialog } from "$lib/shared/components/dialog";
+  import { Button } from "$lib/shared/components/button";
+  import { Field } from "$lib/shared/components/field";
+  import { Input } from "$lib/shared/components/input";
+  import { Select } from "$lib/shared/components/select";
+  import { Checkbox } from "$lib/shared/components/checkbox";
+  import { Icon } from "$lib/shared/components/icon";
+  import { findLayer } from "../core/document/edits";
+  import { FRAME_LABELS } from "../core/document/sources";
+  import type { NodeId } from "../core/document/doc";
+  import {
+    DIGITS,
+    ensureFont,
+    fontOf,
+    glyphBytes,
+    glyphCell,
+    localFamilies,
+    registerFont,
+    renderGlyphs,
+  } from "../core/render/glyphs";
+  import { editorModel } from "../model";
+
+  const {
+    $doc: doc,
+    $glyphDialog: dialog,
+    glyphDialogClosed,
+    glyphsRequested,
+    errored,
+  } = editorModel;
+
+  // The families the app itself ships, plus whatever the user adds — a file they upload or the
+  // installed ones, once they grant the Local Font Access permission.
+  const APP_FAMILIES = [
+    { value: '"Geist Mono", ui-monospace, monospace', label: "Geist Mono (app)" },
+    { value: '"Instrument Serif", Georgia, serif', label: "Instrument Serif (display)" },
+    { value: "system-ui, sans-serif", label: "System sans" },
+    { value: "ui-monospace, monospace", label: "System mono" },
+  ];
+  const WEIGHTS = [300, 400, 500, 600, 700, 800];
+
+  let added = $state<{ value: string; label: string }[]>([]);
+  let family = $state(APP_FAMILIES[0].value);
+  let sizePx = $state(48);
+  let weight = $state(500);
+  let italic = $state(false);
+  let color = $state("#ffffff");
+  let spacing = $state(0);
+  let labelsText = $state(DIGITS.join(" "));
+  let localBusy = $state(false);
+  let fileEl = $state<HTMLInputElement>();
+  let canvasEl = $state<HTMLCanvasElement>();
+  let info = $state("");
+
+  const options = $derived([...added, ...APP_FAMILIES]);
+  const target = $derived($dialog);
+  const layer = $derived(target && $doc ? findLayer($doc, target) : null);
+  // what the widget being replaced has to hold: a value-indexed source fixes both the labels and
+  // their order (index = value), a number wants the ten digits
+  const preset = $derived(
+    layer && layer.kind !== "group" && layer.kind !== "raw"
+      ? (FRAME_LABELS[layer.meta.source] ?? DIGITS)
+      : DIGITS,
+  );
+  const labels = $derived(labelsText.split(/\s+/).filter(Boolean));
+
+  // Re-seed the form when the dialog opens on a different widget, not on every doc change.
+  let openedOn = $state<NodeId | null>(null);
+
+  $effect(() => {
+    if (target === openedOn) return;
+    openedOn = target;
+    if (!target) return;
+    labelsText = preset.join(" ");
+  });
+
+  // Live preview: the same cell maths the generator runs, drawn into one strip.
+  $effect(() => {
+    const font = fontOf(family, sizePx, weight, italic);
+    const set = labels;
+    const [fill, sp] = [color, spacing];
+    let alive = true;
+
+    if (!set.length) {
+      info = "";
+      return;
+    }
+    ensureFont(font).then(() => {
+      if (!alive || !canvasEl) return;
+      const cell = glyphCell(set, font, sizePx, sp);
+      const sprites = renderGlyphs(set, font, fill, cell);
+      const cx = canvasEl.getContext("2d")!;
+
+      canvasEl.width = cell.w * set.length;
+      canvasEl.height = cell.h;
+      sprites.forEach((s, i) => cx.drawImage(s, i * cell.w, 0));
+      const kb = glyphBytes(sprites) / 1024;
+
+      info = `${set.length} sprites · ${cell.w}×${cell.h} px · ${kb.toFixed(1)} KB in the file`;
+    });
+    return () => {
+      alive = false;
+    };
+  });
+
+  async function pickFile(e: Event) {
+    const file = (e.currentTarget as HTMLInputElement).files?.[0];
+
+    if (!file) return;
+    try {
+      const registered = await registerFont(file);
+
+      added = [
+        { value: registered, label: file.name },
+        ...added.filter((o) => o.value !== registered),
+      ];
+      family = registered;
+    } catch {
+      errored(`${file.name} is not a font the browser can read`);
+    }
+  }
+
+  // Chromium-only and permission-gated; an empty answer means "no" and is not an error.
+  async function pickInstalled() {
+    localBusy = true;
+    const families = await localFamilies();
+
+    localBusy = false;
+    if (!families.length) {
+      errored("No access to installed fonts — upload a font file instead");
+      return;
+    }
+    added = families.map((f) => ({ value: `"${f}"`, label: f }));
+    family = added[0].value;
+  }
+
+  // the accent flag is the inspector's own checkbox — nothing to repeat here
+  const generate = () =>
+    target && glyphsRequested({ target, labels, family, sizePx, weight, italic, color, spacing });
+</script>
+
+<Dialog open={Boolean(target)} title="Sprites from a font" onClose={() => glyphDialogClosed()}>
+  <div class="fields">
+    <Field label="Font">
+      <div class="row">
+        <Select bind:value={family} {options} />
+        <span class="tool" title="Upload a .ttf / .otf / .woff">
+          <Button kind="secondary" onClick={() => fileEl?.click()}>
+            <Icon name="upload" size={14} />
+          </Button>
+        </span>
+        <span class="tool" title="Pick from the fonts installed on this machine">
+          <Button kind="secondary" disabled={localBusy} onClick={pickInstalled}>
+            <Icon name="abc" size={16} />
+          </Button>
+        </span>
+      </div>
+    </Field>
+    <input
+      bind:this={fileEl}
+      type="file"
+      accept=".ttf,.otf,.woff,.woff2,font/*"
+      hidden
+      onchange={pickFile}
+    />
+    <div class="grid">
+      <Field label="Size">
+        <Input
+          type="number"
+          min={4}
+          max={400}
+          value={String(sizePx)}
+          onInput={(v) => (sizePx = Math.min(400, Math.max(4, Math.round(+v) || 4)))}
+        />
+      </Field>
+      <Field label="Weight">
+        <Select
+          value={String(weight)}
+          options={WEIGHTS.map((w) => ({ value: String(w), label: String(w) }))}
+          onChange={(v) => (weight = +v)}
+        />
+      </Field>
+      <Field label="Spacing">
+        <Input
+          type="number"
+          min={-20}
+          max={80}
+          value={String(spacing)}
+          onInput={(v) => (spacing = Math.min(80, Math.max(-20, Math.round(+v) || 0)))}
+        />
+      </Field>
+    </div>
+    <div class="grid">
+      <Field label="Color">
+        <div class="row">
+          <input class="swatch" type="color" bind:value={color} aria-label="Glyph color" />
+          <Input bind:value={color} maxlength={7} />
+        </div>
+      </Field>
+      <Field label="Style">
+        <label class="check">
+          <Checkbox bind:checked={italic} />
+          italic
+        </label>
+      </Field>
+    </div>
+    <Field label="Characters" hint="space-separated — index = value, keep the watch's order">
+      <Input bind:value={labelsText} />
+    </Field>
+  </div>
+
+  <div class="preview">
+    <canvas bind:this={canvasEl}></canvas>
+  </div>
+  <p class="info">{info}</p>
+
+  <div class="footer">
+    <Button kind="ghost" onClick={() => glyphDialogClosed()}>Cancel</Button>
+    <Button kind="primary" disabled={!$doc || !labels.length} onClick={generate}>
+      Replace frames
+    </Button>
+  </div>
+</Dialog>
+
+<style>
+  .fields {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 0.5rem;
+  }
+  .row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+
+    & :global(select),
+    & :global(input) {
+      min-width: 0;
+    }
+  }
+  .tool {
+    flex-shrink: 0;
+    display: inline-flex;
+  }
+  .check {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.75rem;
+    cursor: pointer;
+  }
+  .swatch {
+    flex-shrink: 0;
+    width: 1.875rem; /* the row's height — everything in here is button-sized */
+    height: 1.875rem;
+    padding: 0;
+    border: 1px solid oklch(from var(--color-text) l c h / 12%);
+    border-radius: var(--border-radius);
+    background: transparent;
+    cursor: pointer;
+  }
+  /* the watch panel is black, and white-on-white would preview as nothing at all */
+  .preview {
+    margin-top: 0.75rem;
+    padding: 0.5rem;
+    border-radius: var(--border-radius);
+    background: #000;
+    overflow-x: auto;
+  }
+  canvas {
+    display: block;
+    max-width: 100%;
+    height: auto;
+  }
+  .info {
+    margin: 0.375rem 0 0;
+    font-size: 0.625rem;
+    color: oklch(from var(--color-text) l c h / 55%);
+  }
+  .footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+    margin-top: 1rem;
+  }
+</style>

--- a/src/lib/modules/editor/components/GlyphsDialog.svelte
+++ b/src/lib/modules/editor/components/GlyphsDialog.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
-  // Regenerate the selected widget's sprites from a font instead of hand-made PNGs: the ten
-  // digits of a number, the labels of a value-indexed set. Everything here is preview — the
-  // sprites that end up in the document are rasterized again in glyphsFx, off the same pure
-  // functions, so what you see is what gets encoded.
+  // The generator's dialog. Every setting, the font list and the preview strip live in
+  // font-sprite.model — this only renders them and fires events.
   import { Dialog } from "$lib/shared/components/dialog";
   import { Button } from "$lib/shared/components/button";
   import { Field } from "$lib/shared/components/field";
@@ -10,151 +8,69 @@
   import { Select } from "$lib/shared/components/select";
   import { Checkbox } from "$lib/shared/components/checkbox";
   import { Icon } from "$lib/shared/components/icon";
-  import { findLayer } from "../core/document/edits";
-  import { FRAME_LABELS } from "../core/document/sources";
-  import type { NodeId } from "../core/document/doc";
-  import {
-    DIGITS,
-    ensureFont,
-    fontOf,
-    glyphBytes,
-    glyphCell,
-    localFamilies,
-    registerFont,
-    renderGlyphs,
-  } from "../core/render/glyphs";
   import { editorModel } from "../model";
+  import { labelsOf, WEIGHTS } from "../model/font-sprite.model";
 
   const {
-    $doc: doc,
-    $glyphDialog: dialog,
+    $glyphDialog: target,
+    $glyphForm: form,
+    $fontOptions: fontOptions,
+    $glyphPreview: preview,
+    $localFontsPending: localPending,
     glyphDialogClosed,
-    glyphsRequested,
-    errored,
+    glyphFormPatched,
+    glyphsGenerateRequested,
+    fontFilePicked,
+    installedFontsRequested,
   } = editorModel;
 
-  // The families the app itself ships, plus whatever the user adds — a file they upload or the
-  // installed ones, once they grant the Local Font Access permission.
-  const APP_FAMILIES = [
-    { value: '"Geist Mono", ui-monospace, monospace', label: "Geist Mono (app)" },
-    { value: '"Instrument Serif", Georgia, serif', label: "Instrument Serif (display)" },
-    { value: "system-ui, sans-serif", label: "System sans" },
-    { value: "ui-monospace, monospace", label: "System mono" },
-  ];
-  const WEIGHTS = [300, 400, 500, 600, 700, 800];
-
-  let added = $state<{ value: string; label: string }[]>([]);
-  let family = $state(APP_FAMILIES[0].value);
-  let sizePx = $state(48);
-  let weight = $state(500);
-  let italic = $state(false);
-  let color = $state("#ffffff");
-  let spacing = $state(0);
-  let labelsText = $state(DIGITS.join(" "));
-  let localBusy = $state(false);
   let fileEl = $state<HTMLInputElement>();
   let canvasEl = $state<HTMLCanvasElement>();
-  let info = $state("");
 
-  const options = $derived([...added, ...APP_FAMILIES]);
-  const target = $derived($dialog);
-  const layer = $derived(target && $doc ? findLayer($doc, target) : null);
-  // what the widget being replaced has to hold: a value-indexed source fixes both the labels and
-  // their order (index = value), a number wants the ten digits
-  const preset = $derived(
-    layer && layer.kind !== "group" && layer.kind !== "raw"
-      ? (FRAME_LABELS[layer.meta.source] ?? DIGITS)
-      : DIGITS,
-  );
-  const labels = $derived(labelsText.split(/\s+/).filter(Boolean));
+  const clamp = (v: string, lo: number, hi: number, fallback: number) =>
+    Math.min(hi, Math.max(lo, Math.round(Number(v)) || fallback));
 
-  // Re-seed the form when the dialog opens on a different widget, not on every doc change.
-  let openedOn = $state<NodeId | null>(null);
-
+  // the sprites are already rasterized — this only lays them out side by side
   $effect(() => {
-    if (target === openedOn) return;
-    openedOn = target;
-    if (!target) return;
-    labelsText = preset.join(" ");
+    const strip = $preview;
+
+    if (!canvasEl || !strip) return;
+    const cx = canvasEl.getContext("2d")!;
+
+    canvasEl.width = strip.w * strip.bitmaps.length;
+    canvasEl.height = strip.h;
+    strip.bitmaps.forEach((b, i) => cx.drawImage(b, i * strip.w, 0));
   });
 
-  // Live preview: the same cell maths the generator runs, drawn into one strip.
-  $effect(() => {
-    const font = fontOf(family, sizePx, weight, italic);
-    const set = labels;
-    const [fill, sp] = [color, spacing];
-    let alive = true;
+  function pickFile(e: Event) {
+    const el = e.currentTarget as HTMLInputElement;
+    const file = el.files?.[0];
 
-    if (!set.length) {
-      info = "";
-      return;
-    }
-    ensureFont(font).then(() => {
-      if (!alive || !canvasEl) return;
-      const cell = glyphCell(set, font, sizePx, sp);
-      const sprites = renderGlyphs(set, font, fill, cell);
-      const cx = canvasEl.getContext("2d")!;
-
-      canvasEl.width = cell.w * set.length;
-      canvasEl.height = cell.h;
-      sprites.forEach((s, i) => cx.drawImage(s, i * cell.w, 0));
-      const kb = glyphBytes(sprites) / 1024;
-
-      info = `${set.length} sprites · ${cell.w}×${cell.h} px · ${kb.toFixed(1)} KB in the file`;
-    });
-    return () => {
-      alive = false;
-    };
-  });
-
-  async function pickFile(e: Event) {
-    const file = (e.currentTarget as HTMLInputElement).files?.[0];
-
-    if (!file) return;
-    try {
-      const registered = await registerFont(file);
-
-      added = [
-        { value: registered, label: file.name },
-        ...added.filter((o) => o.value !== registered),
-      ];
-      family = registered;
-    } catch {
-      errored(`${file.name} is not a font the browser can read`);
-    }
+    el.value = ""; // so picking the same file again still fires a change
+    if (file) fontFilePicked(file);
   }
-
-  // Chromium-only and permission-gated; an empty answer means "no" and is not an error.
-  async function pickInstalled() {
-    localBusy = true;
-    const families = await localFamilies();
-
-    localBusy = false;
-    if (!families.length) {
-      errored("No access to installed fonts — upload a font file instead");
-      return;
-    }
-    added = families.map((f) => ({ value: `"${f}"`, label: f }));
-    family = added[0].value;
-  }
-
-  // the accent flag is the inspector's own checkbox — nothing to repeat here
-  const generate = () =>
-    target && glyphsRequested({ target, labels, family, sizePx, weight, italic, color, spacing });
 </script>
 
-<Dialog open={Boolean(target)} title="Sprites from a font" onClose={() => glyphDialogClosed()}>
+<Dialog open={Boolean($target)} title="Sprites from a font" onClose={() => glyphDialogClosed()}>
   <div class="fields">
     <Field label="Font">
       <div class="row">
-        <Select bind:value={family} {options} />
+        <Select
+          value={$form.family}
+          options={$fontOptions}
+          onChange={(family) => glyphFormPatched({ family })}
+        />
         <span class="tool" title="Upload a .ttf / .otf / .woff">
           <Button kind="secondary" onClick={() => fileEl?.click()}>
             <Icon name="upload" size={14} />
           </Button>
         </span>
         <span class="tool" title="Pick from the fonts installed on this machine">
-          <Button kind="secondary" disabled={localBusy} onClick={pickInstalled}>
+          <Button
+            kind="secondary"
+            disabled={$localPending}
+            onClick={() => installedFontsRequested()}
+          >
             <Icon name="abc" size={16} />
           </Button>
         </span>
@@ -173,15 +89,15 @@
           type="number"
           min={4}
           max={400}
-          value={String(sizePx)}
-          onInput={(v) => (sizePx = Math.min(400, Math.max(4, Math.round(+v) || 4)))}
+          value={String($form.sizePx)}
+          onInput={(v) => glyphFormPatched({ sizePx: clamp(v, 4, 400, 4) })}
         />
       </Field>
       <Field label="Weight">
         <Select
-          value={String(weight)}
+          value={String($form.weight)}
           options={WEIGHTS.map((w) => ({ value: String(w), label: String(w) }))}
-          onChange={(v) => (weight = +v)}
+          onChange={(v) => glyphFormPatched({ weight: +v })}
         />
       </Field>
       <Field label="Spacing">
@@ -189,38 +105,57 @@
           type="number"
           min={-20}
           max={80}
-          value={String(spacing)}
-          onInput={(v) => (spacing = Math.min(80, Math.max(-20, Math.round(+v) || 0)))}
+          value={String($form.spacing)}
+          onInput={(v) => glyphFormPatched({ spacing: clamp(v, -20, 80, 0) })}
         />
       </Field>
     </div>
     <div class="grid">
       <Field label="Color">
         <div class="row">
-          <input class="swatch" type="color" bind:value={color} aria-label="Glyph color" />
-          <Input bind:value={color} maxlength={7} />
+          <input
+            class="swatch"
+            type="color"
+            value={$form.color}
+            aria-label="Glyph color"
+            oninput={(e) => glyphFormPatched({ color: e.currentTarget.value })}
+          />
+          <Input
+            value={$form.color}
+            maxlength={7}
+            onInput={(color) => glyphFormPatched({ color })}
+          />
         </div>
       </Field>
       <Field label="Style">
         <label class="check">
-          <Checkbox bind:checked={italic} />
+          <Checkbox checked={$form.italic} onChange={(italic) => glyphFormPatched({ italic })} />
           italic
         </label>
       </Field>
     </div>
     <Field label="Characters" hint="space-separated — index = value, keep the watch's order">
-      <Input bind:value={labelsText} />
+      <Input value={$form.labelsText} onInput={(labelsText) => glyphFormPatched({ labelsText })} />
     </Field>
   </div>
 
   <div class="preview">
     <canvas bind:this={canvasEl}></canvas>
   </div>
-  <p class="info">{info}</p>
+  <p class="info">
+    {#if $preview}
+      {$preview.bitmaps.length} sprites · {$preview.w}×{$preview.h} px ·
+      {($preview.bytes / 1024).toFixed(1)} KB in the file
+    {/if}
+  </p>
 
   <div class="footer">
     <Button kind="ghost" onClick={() => glyphDialogClosed()}>Cancel</Button>
-    <Button kind="primary" disabled={!$doc || !labels.length} onClick={generate}>
+    <Button
+      kind="primary"
+      disabled={!labelsOf($form).length}
+      onClick={() => glyphsGenerateRequested()}
+    >
       Replace frames
     </Button>
   </div>

--- a/src/lib/modules/editor/components/TreePanel.svelte
+++ b/src/lib/modules/editor/components/TreePanel.svelte
@@ -21,6 +21,7 @@
     aodRemoved,
     layerFlagsSet,
     widgetAdded,
+    numberAdded,
     deleteRequested,
     duplicateRequested,
     copyRequested,
@@ -74,7 +75,7 @@
   // a <label><input type=file> can't live inside a MenuItem's own <button>
   let fileInput = $state<Record<string, HTMLInputElement | undefined>>({});
 
-  function onAdd(kind: "image" | "number" | "hand", e: Event) {
+  function onAdd(kind: "image" | "hand", e: Event) {
     const t = e.target as HTMLInputElement;
     const files = t.files;
 
@@ -224,14 +225,6 @@
       onchange={(e) => onAdd("image", e)}
     />
     <input
-      bind:this={fileInput.number}
-      type="file"
-      accept="image/*"
-      multiple
-      hidden
-      onchange={(e) => onAdd("number", e)}
-    />
-    <input
       bind:this={fileInput.hand}
       type="file"
       accept="image/*"
@@ -249,8 +242,10 @@
       <MenuItem onClick={() => fileInput.image?.click()}>
         <Icon name="image" size={14} /> Image…
       </MenuItem>
-      <MenuItem onClick={() => fileInput.number?.click()}>
-        <Icon name="hash" size={14} /> Number…
+      <!-- ten blank frames: the art comes from the inspector, either "regenerate from a font"
+           or a PNG dropped on a single frame — no ten-file picker any more -->
+      <MenuItem onClick={() => numberAdded()}>
+        <Icon name="hash" size={14} /> Number
       </MenuItem>
       <MenuItem onClick={() => fileInput.hand?.click()}>
         <Icon name="clock-3" size={14} /> Hand…

--- a/src/lib/modules/editor/components/props/frames.svelte
+++ b/src/lib/modules/editor/components/props/frames.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { Select } from "$lib/shared/components/select";
+  import { Button } from "$lib/shared/components/button";
   import { Icon } from "$lib/shared/components/icon";
   import { framesOf, type ImageId, type Layer } from "../../core/document/doc";
   import { FRAME_LABELS, pickerLabel } from "../../core/document/sources";
@@ -8,7 +9,13 @@
   import FrameThumb from "./frame-thumb.svelte";
 
   const { layer }: { layer: Layer } = $props();
-  const { $doc: doc, $cache: cache, replaceImageRequested, frameMoved } = editorModel;
+  const {
+    $doc: doc,
+    $cache: cache,
+    replaceImageRequested,
+    frameMoved,
+    glyphDialogOpened,
+  } = editorModel;
 
   // native HTML5 drag & drop over the frame list, same shape as TreePanel's layer reorder
   let dragIdx = $state<number | null>(null);
@@ -95,6 +102,17 @@
 {:else if images}
   <div class="images">
     {#each images as ri}{@render thumb(ri)}{/each}
+  </div>
+{/if}
+
+<!-- A set whose contents are spelled out by the format — the ten digits of a number, the labels
+     of a value-indexed source — can be rasterized from a font instead of drawn by hand. -->
+{#if layer.kind === "number" || frameLabels}
+  <div class="row">
+    <Button kind="secondary" onClick={() => glyphDialogOpened(layer.id)}>
+      <Icon name="type" size={14} />
+      regenerate from a font
+    </Button>
   </div>
 {/if}
 

--- a/src/lib/modules/editor/core/import/facer/assets.ts
+++ b/src/lib/modules/editor/core/import/facer/assets.ts
@@ -1,6 +1,7 @@
 // Reading a Facer export directory: files by name, images (base64 or PNG), fonts, colours,
 // and the canvas helpers that turn any of it into a face Resource.
-import { encodePixels, type Resource } from "../../format";
+import { type Resource } from "../../format";
+import { resourceFromCanvas } from "../../render/pixels";
 
 // fileMap/encodeCanvas/encodeJpeg/cropOpaque are shared with ./watchmaker — this was the
 // first importer written; if a third export format shows up, move them to their own module.
@@ -73,9 +74,7 @@ export function tinted(
 }
 
 export function encodeCanvas(canvas: OffscreenCanvas, cf: number): Promise<Resource> {
-  const cx = canvas.getContext("2d")!;
-  const { width: w, height: h } = canvas;
-  const r = encodePixels(cx.getImageData(0, 0, w, h).data, w, h, cf);
+  const r = resourceFromCanvas(canvas, cf);
 
   return createImageBitmap(canvas).then((b) => ((r.bitmap = b), r));
 }
@@ -117,13 +116,13 @@ export function cropOpaque(
 export const fontCache = new Map<string, string>();
 
 export async function loadFont(map: Map<string, File>, name?: string): Promise<string> {
-  if (!name) return "bold sans-serif";
+  if (!name) return "sans-serif";
   if (fontCache.has(name)) return fontCache.get(name)!;
   const f = map.get(`fonts/${name}`) || map.get(name);
 
   if (!f) {
-    fontCache.set(name, "bold sans-serif");
-    return "bold sans-serif";
+    fontCache.set(name, "sans-serif");
+    return "sans-serif";
   }
   const family = `facer_${name.replace(/\W/g, "_")}`;
 
@@ -135,7 +134,7 @@ export async function loadFont(map: Map<string, File>, name?: string): Promise<s
     fontCache.set(name, family);
     return family;
   } catch {
-    fontCache.set(name, "bold sans-serif");
-    return "bold sans-serif";
+    fontCache.set(name, "sans-serif");
+    return "sans-serif";
   }
 }

--- a/src/lib/modules/editor/core/import/facer/index.ts
+++ b/src/lib/modules/editor/core/import/facer/index.ts
@@ -20,6 +20,7 @@ import { SCREEN } from "../../render/screen";
 import {
   classifyText,
   DIGITS,
+  fontOf,
   glyphCell,
   isLive,
   renderGlyphs,
@@ -459,21 +460,21 @@ export async function facerToFace(files: File[]): Promise<{ face: Face; skipped:
     if (cls.type !== "row") throw new Error("unreachable");
     const family = await loadFont(map, l.new_font_name);
     const sizePx = Math.round(num(l.size) * s) || 20;
+    const font = fontOf(family, sizePx);
     const color = rgba(argb(ambient ? (l.low_power_color ?? l.color) : l.color));
     const labelsOf = (p: Part) => (!isLive(p) ? [p.text] : p.type === "select" ? p.labels : DIGITS);
     // one vertical metric across every part so the whole row shares a baseline
-    const tall = glyphCell(cls.parts.flatMap(labelsOf), family, sizePx);
+    const tall = glyphCell(cls.parts.flatMap(labelsOf), font, sizePx);
     const sprites = new Map<string, number[]>(); // hour and minute share one digit set
     const cellOf = async (p: Part) => {
       const labels = labelsOf(p);
-      const cell = { ...glyphCell(labels, family, sizePx), h: tall.h, base: tall.base };
+      const cell = { ...glyphCell(labels, font, sizePx), h: tall.h, base: tall.base };
       const key = labels.join("|");
 
       if (!sprites.has(key)) {
         const res: number[] = [];
 
-        for (const sp of renderGlyphs(labels, family, sizePx, color, cell))
-          res.push(await addRes(sp, 5));
+        for (const sp of renderGlyphs(labels, font, color, cell)) res.push(await addRes(sp, 5));
         sprites.set(key, res);
       }
       return { cell, images: sprites.get(key)! };

--- a/src/lib/modules/editor/core/import/facer/text.ts
+++ b/src/lib/modules/editor/core/import/facer/text.ts
@@ -1,7 +1,8 @@
 // Facer's text templates: the tag language ("#DmZ#", "$#DMM#=01?JAN:$", digit-splitting
-// expressions) mapped onto CMF widgets, plus the glyph rasterizer that bakes each value of a
-// field into an equal-sized sprite.
-export const DIGITS = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"];
+// expressions) mapped onto CMF widgets. The glyph rasterizer that bakes each value of a field
+// into an equal-sized sprite moved to ../../render/glyphs — the editor generates the same sets
+// from a font now, and re-exported here so the importer's own imports stay in one place.
+export { DIGITS, fontOf, glyphCell, renderGlyphs, type Cell } from "../../render/glyphs";
 // Sunday-first — device order, read off the stock Combo/Elaborate_2 weekday sprite lists
 // (frame 0 = "Sun"), i.e. the watch indexes with JS getDay().
 export const WEEKDAYS = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"];
@@ -19,56 +20,6 @@ export const MONTHS = [
   "OCT",
   "NOV",
 ];
-
-// renderGlyphs: rasterize each label into an equal-size sprite (widest cell across all),
-// so a digit font or a weekday selector never shifts when the value changes. `base` is the
-// text baseline inside the cell — Facer positions text by its baseline, so a field's y is
-// the layer's y minus this.
-export interface Cell {
-  w: number;
-  h: number;
-  base: number;
-}
-
-export function glyphCell(labels: string[], family: string, sizePx: number): Cell {
-  const meas = new OffscreenCanvas(4, 4).getContext("2d")!;
-
-  meas.font = `${sizePx}px ${family}`;
-  let w = 1,
-    asc = 0,
-    desc = 0;
-
-  for (const s of labels) {
-    const m = meas.measureText(s);
-
-    w = Math.max(w, Math.ceil(m.width));
-    asc = Math.max(asc, m.actualBoundingBoxAscent || sizePx * 0.75);
-    desc = Math.max(desc, m.actualBoundingBoxDescent || sizePx * 0.25);
-  }
-  const base = Math.ceil(asc) + 2;
-
-  return { w: w + 4, h: base + Math.ceil(desc) + 2, base }; // +4: room for antialiasing
-}
-
-export function renderGlyphs(
-  labels: string[],
-  family: string,
-  sizePx: number,
-  color: string,
-  cell: Cell,
-) {
-  return labels.map((s) => {
-    const c = new OffscreenCanvas(cell.w, cell.h);
-    const cx = c.getContext("2d")!;
-
-    cx.font = `${sizePx}px ${family}`;
-    cx.fillStyle = color;
-    cx.textAlign = "center";
-    cx.textBaseline = "alphabetic";
-    cx.fillText(s, cell.w / 2, cell.base);
-    return c;
-  });
-}
 
 // Facer spells a per-value thing out as one layer (or one conditional) per value: seven
 // weekday sprites stacked at one spot, twelve month names chained in a template. That's

--- a/src/lib/modules/editor/core/render/glyphs.ts
+++ b/src/lib/modules/editor/core/render/glyphs.ts
@@ -1,0 +1,139 @@
+// Text -> sprites. The format has no text rendering at all: a number widget is ten bitmaps and a
+// weekday selector seven, so every label a face shows has to be rasterized first. Written for the
+// Facer importer, which bakes the same sets out of a template; the editor's own "from a font"
+// generator is the second caller, which is why this sits here and not under import/facer.
+import { resourceFromCanvas } from "./pixels";
+
+export const DIGITS = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"];
+
+/** cf 5 — RGB565 + 8-bit alpha, the one format that keeps antialiased edges. */
+export const GLYPH_CF = 5;
+
+/** The cell every sprite of a set shares. `base` is the text baseline inside it — Facer positions
+ *  text by its baseline, so a field's y is the layer's y minus this. */
+export interface Cell {
+  w: number;
+  h: number;
+  base: number;
+}
+
+/** A CSS font shorthand — what both measuring and drawing take. */
+export const fontOf = (
+  family: string,
+  sizePx: number,
+  weight: number | string = 400,
+  italic = false,
+) => `${italic ? "italic " : ""}${weight} ${sizePx}px ${family}`;
+
+/** A family may not be rasterized yet (a webfont, or one just registered from a file) — measuring
+ *  before it loads silently falls back to the default face and every metric comes out wrong. */
+export const ensureFont = (font: string) => document.fonts.load(font).catch(() => []);
+
+// One cell wide enough for every label in the set: the number widget lays its glyphs out edge to
+// edge (`cx += b.width` in drawDigits), so unequal widths make the value jitter as it changes.
+// `spacing` widens the cell without moving the glyph — tracking, since there is nothing between
+// two sprites to space out.
+export function glyphCell(labels: string[], font: string, sizePx: number, spacing = 0): Cell {
+  const meas = new OffscreenCanvas(4, 4).getContext("2d")!;
+
+  meas.font = font;
+  let w = 1,
+    asc = 0,
+    desc = 0;
+
+  for (const s of labels) {
+    const m = meas.measureText(s);
+
+    w = Math.max(w, Math.ceil(m.width));
+    asc = Math.max(asc, m.actualBoundingBoxAscent || sizePx * 0.75);
+    desc = Math.max(desc, m.actualBoundingBoxDescent || sizePx * 0.25);
+  }
+  const base = Math.ceil(asc) + 2;
+
+  return { w: Math.max(1, w + CELL_PAD + spacing), h: base + Math.ceil(desc) + 2, base };
+}
+
+/** Room for antialiasing around the glyph, on both axes. Fixed, so it is what a resize has to
+ *  take off both sizes before working out how much the point size itself has to change. */
+export const CELL_PAD = 4;
+
+/** Rasterize each label centered in the shared cell. */
+export function renderGlyphs(labels: string[], font: string, color: string, cell: Cell) {
+  return labels.map((s) => {
+    const c = new OffscreenCanvas(cell.w, cell.h);
+    const cx = c.getContext("2d")!;
+
+    cx.font = font;
+    cx.fillStyle = color;
+    cx.textAlign = "center";
+    cx.textBaseline = "alphabetic";
+    cx.fillText(s, cell.w / 2, cell.base);
+    return c;
+  });
+}
+
+/** Everything needed to rasterize a set — kept around by the editor so a resize can re-render at
+ *  the new size instead of scaling the bitmaps, which is what makes big digits soft. */
+export type GlyphSpec = {
+  labels: readonly string[];
+  family: string;
+  sizePx: number;
+  weight: number;
+  italic: boolean;
+  color: string;
+  /** Extra cell width. The sprites are drawn edge to edge, so tracking is all there is to space. */
+  spacing: number;
+};
+
+/** The sprites a spec describes, encoded and decoded: what the generator stores and what a resize
+ *  re-renders. Empty labels are dropped — the caller's text field is free-form. */
+export async function glyphSprites(spec: GlyphSpec, cf = GLYPH_CF) {
+  const labels = spec.labels.filter((s) => s.length);
+  const font = fontOf(spec.family, spec.sizePx, spec.weight, spec.italic);
+
+  await ensureFont(font);
+  const cell = glyphCell(labels, font, spec.sizePx, spec.spacing);
+
+  return Promise.all(
+    renderGlyphs(labels, font, spec.color, cell).map(async (canvas) => ({
+      resource: resourceFromCanvas(canvas, cf),
+      bitmap: await createImageBitmap(canvas),
+    })),
+  );
+}
+
+/** What a set costs in the file: the same LZ4'd payloads buildBin writes, summed. */
+export const glyphBytes = (sprites: OffscreenCanvas[], cf = GLYPH_CF) =>
+  sprites.reduce((n, c) => n + resourceFromCanvas(c, cf).data.length, 0);
+
+// A font file the user picked, registered under a family name of our own so it can't collide with
+// an installed one. Keyed by name+size: re-picking the same file must not register it twice.
+const registered = new Map<string, string>();
+
+export async function registerFont(file: File): Promise<string> {
+  const key = `${file.name}:${file.size}`;
+  const hit = registered.get(key);
+
+  if (hit) return hit;
+  const family = `fmc_${file.name.replace(/\W/g, "_")}`;
+  const ff = new FontFace(family, await file.arrayBuffer());
+
+  await ff.load();
+  document.fonts.add(ff);
+  registered.set(key, family);
+  return family;
+}
+
+/** Installed families, via the Local Font Access API. Chromium-only and permission-gated, so an
+ *  empty list is a normal answer — the caller falls back to the families the app ships. */
+export async function localFamilies(): Promise<string[]> {
+  const query = (window as unknown as { queryLocalFonts?: () => Promise<{ family: string }[]> })
+    .queryLocalFonts;
+
+  if (!query) return [];
+  try {
+    return [...new Set((await query.call(window)).map((f) => f.family))].sort();
+  } catch {
+    return []; // permission denied — not an error worth showing
+  }
+}

--- a/src/lib/modules/editor/core/render/glyphs.ts
+++ b/src/lib/modules/editor/core/render/glyphs.ts
@@ -102,10 +102,6 @@ export async function glyphSprites(spec: GlyphSpec, cf = GLYPH_CF) {
   );
 }
 
-/** What a set costs in the file: the same LZ4'd payloads buildBin writes, summed. */
-export const glyphBytes = (sprites: OffscreenCanvas[], cf = GLYPH_CF) =>
-  sprites.reduce((n, c) => n + resourceFromCanvas(c, cf).data.length, 0);
-
 // A font file the user picked, registered under a family name of our own so it can't collide with
 // an installed one. Keyed by name+size: re-picking the same file must not register it twice.
 const registered = new Map<string, string>();

--- a/src/lib/modules/editor/core/render/pixels.ts
+++ b/src/lib/modules/editor/core/render/pixels.ts
@@ -69,6 +69,14 @@ export async function encodeBitmap(
   return encodePixels(pixelsOf(b, w, h, filter), w, h, cf).data;
 }
 
+/** A canvas as a resource — the encode side of pixelsOf. No bitmap: the caller already has the
+ *  canvas, and `createImageBitmap` on it is cheaper than decoding what was just encoded. */
+export function resourceFromCanvas(canvas: OffscreenCanvas, cf: number): Resource {
+  const { width: w, height: h } = canvas;
+
+  return encodePixels(canvas.getContext("2d")!.getImageData(0, 0, w, h).data, w, h, cf);
+}
+
 /** A dropped/picked image file as a ready-to-use resource (bitmap included). */
 export async function resourceFromFile(file: File, cf: number): Promise<Resource> {
   const img = await createImageBitmap(file);

--- a/src/lib/modules/editor/model/assets.model.ts
+++ b/src/lib/modules/editor/model/assets.model.ts
@@ -14,6 +14,7 @@ import {
   invertAsset,
   resourceFromFile,
 } from "../core/render/pixels";
+import { CELL_PAD, glyphSprites, type GlyphSpec } from "../core/render/glyphs";
 import {
   framesOf,
   type Doc,
@@ -35,6 +36,13 @@ import { errored } from "./ui.model";
  *  resize keeps the pinned original. Move it into ImageCache if that ever bites. */
 let pivot0 = new Map<NodeId, { x: number; y: number }>();
 
+/** How each font-generated widget was rasterized, so a resize can re-render at the new size
+ *  instead of scaling the pixels — the whole reason to generate sprites rather than draw them.
+ *  Per-session like the cache: after a reload (or for art that never came from a font) there is
+ *  no spec and a resize rescales, as before. Also stale after an undo across a regeneration —
+ *  ponytail: the next resize then re-renders the newer spec, which is a redo, not corruption. */
+let glyphSpecs = new Map<NodeId, GlyphSpec>();
+
 const asResource = (a: ImageAsset): Resource => ({ cf: a.cf, w: a.w, h: a.h, data: a.data });
 
 // ---- stores ----
@@ -50,6 +58,8 @@ export const $store = combine(
 /** Merge decoded bitmaps into the cache — the one way $cache changes. */
 export const cachePatched = createEvent<ReadonlyMap<ImageId, ImageCache>>();
 export const replaceImageRequested = createEvent<{ id: ImageId; file: File }>();
+/** "These frames came out of this font" — fired by the generator, read by the resize. */
+export const glyphSpecRemembered = createEvent<{ layer: NodeId; spec: GlyphSpec }>();
 /** w/h: target size of the layer's FIRST frame; `at`: the origin it must end up at, so a corner
  *  drag can anchor the opposite corner in the same update. */
 export const resizeImageRequested = createEvent<{
@@ -194,6 +204,30 @@ const resizeImageFx = attach({
     if (tw === first.w && th === first.h && !at) return null;
     const assets = new Map<ImageId, ImageAsset>();
     const cached = new Map<ImageId, ImageCache>();
+    // Generated sprites re-render instead of rescaling: the font has the shape at any size, the
+    // bitmap only has it at the one it was drawn. The point size follows the height (the width is
+    // the font's own business), and the fresh spec is kept so the next drag scales from it.
+    const spec = glyphSpecs.get(l.id);
+
+    if (spec && spec.labels.length === frames.length) {
+      // the cell's padding doesn't scale, so it comes off both heights before the ratio
+      const k = Math.max(0.05, (th - CELL_PAD) / Math.max(1, first.h - CELL_PAD));
+      const next = { ...spec, sizePx: spec.sizePx * k, spacing: spec.spacing * k };
+      const sprites = await glyphSprites(next);
+
+      frames.forEach((id, i) => {
+        const a = doc.images.get(id);
+        const { resource: r, bitmap } = sprites[i];
+
+        if (!a) return;
+        assets.set(id, { ...a, cf: r.cf, w: r.w, h: r.h, data: r.data });
+        // no `original`: these pixels ARE the source now, and flushAssets must not re-encode
+        // them from a stale bitmap of the old size
+        cached.set(id, { bitmap, original: undefined, accent: undefined });
+      });
+      glyphSpecs.set(l.id, next);
+      return { assets, cache: cached, layer: l.id, patch: at ? { x: at.x, y: at.y } : {} };
+    }
     const scaled = await rescaleFrames(doc, cache, frames, tw, th, assets, cached);
 
     if (!scaled) return null;
@@ -586,13 +620,24 @@ sample({
   target: errored,
 });
 
-// the pinned pivots and decoded bitmaps belong to the document that was open — dropped before
-// decodeAllFx refills the cache for the new one
+// the pinned pivots, glyph specs and decoded bitmaps belong to the document that was open —
+// dropped before decodeAllFx refills the cache for the new one
 const resetSessionFx = createEffect(() => {
   pivot0 = new Map();
+  glyphSpecs = new Map();
 });
 
 sample({
   clock: docLoaded,
   target: resetSessionFx,
+});
+
+// Module state, so writing it is an effect — same shape as the frame stash in edit.model.
+const rememberGlyphSpecFx = createEffect(({ layer, spec }: { layer: NodeId; spec: GlyphSpec }) => {
+  glyphSpecs.set(layer, spec);
+});
+
+sample({
+  clock: glyphSpecRemembered,
+  target: rememberGlyphSpecFx,
 });

--- a/src/lib/modules/editor/model/edit.model.ts
+++ b/src/lib/modules/editor/model/edit.model.ts
@@ -5,6 +5,7 @@ import { attach, createEffect, createEvent, createStore, sample } from "effector
 import { PREVIEW, SCREEN } from "../core/render/screen";
 import { renderDoc } from "../core/render/render";
 import { blankFrame, opaqueBlack, resourceFromFile } from "../core/render/pixels";
+import { glyphSprites, type GlyphSpec } from "../core/render/glyphs";
 import {
   addLayer,
   assetsOf,
@@ -48,13 +49,15 @@ import {
 } from "../core/document/doc";
 import { $doc, committed, docLoaded } from "./doc.model";
 import { $screen, $sel, $selected, screenSet, select, selectionSet } from "./selection.model";
-import { $cache, cachePatched } from "./assets.model";
+import { $cache, cachePatched, glyphSpecRemembered } from "./assets.model";
 import { $sim } from "./sim.model";
-import { errored } from "./ui.model";
+import { errored, glyphDialogClosed } from "./ui.model";
 
 /** Figma-style alignment direction. */
 export type AlignDir = "left" | "hcenter" | "right" | "top" | "vcenter" | "bottom";
-export type WidgetKind = "image" | "number" | "hand";
+/** The widgets that are created FROM files. A number isn't one of them — its ten frames start
+ *  blank and are filled from a font (see numberAdded / glyphsRequested). */
+export type WidgetKind = "image" | "hand";
 
 /** Frames dropped by a shrinking source change, keyed by layer. Switching month (12 frames) to
  *  weekday (7) trims the run but keeps the originals here, so switching back restores the art
@@ -70,6 +73,13 @@ const withAssets = (doc: Doc, added: ReadonlyMap<ImageId, ImageAsset>): Doc => (
 export const deleteRequested = createEvent();
 export const nodeAdded = createEvent<"group" | "ring">();
 export const widgetAdded = createEvent<{ kind: WidgetKind; files: File[] }>();
+/** Rasterize a set of labels into the target widget's frames: the ten digits of a number, the
+ *  labels of a value-indexed set. Replaces what the layer draws — the layer itself stays. */
+export type GlyphRequest = GlyphSpec & { target: NodeId };
+export const glyphsRequested = createEvent<GlyphRequest>();
+/** A number widget. Always created empty — ten blank frames, filled from a font afterwards; the
+ *  ten-PNG picker this used to open is what the font generator replaces. */
+export const numberAdded = createEvent();
 export const slotAdded = createEvent();
 /** Give the face an always-on screen. A new document starts with the main screen only, and until
  *  this runs the AOD tab has nothing to show. */
@@ -132,10 +142,51 @@ const addWidgetFx = attach({
     }
     const ids = [...assets.keys()];
     const first = assets.get(ids[0])!;
-    const layer =
-      kind === "image" ? newImage(ids) : kind === "number" ? newNumber(ids) : newHand(ids, first);
 
-    return { screen, assets, cache, layer };
+    return { screen, assets, cache, layer: kind === "image" ? newImage(ids) : newHand(ids, first) };
+  },
+});
+
+// The font generator: one sprite per label, all sharing the widest cell so the value can't shift
+// as it changes — that is the whole point of generating a digit set rather than drawing ten PNGs
+// by hand (drawDigits packs the glyphs edge to edge, so unequal widths make the number jitter).
+const glyphsFx = attach({
+  source: $doc,
+  async effect(doc, spec: GlyphRequest) {
+    const target = doc ? findLayer(doc, spec.target) : null;
+
+    if (!doc || !spec.labels.some((s) => s.length) || !target) return null;
+    if (target.kind === "group" || target.kind === "raw" || target.locked) return null;
+    const assets = new Map<ImageId, ImageAsset>();
+    const cache = new Map<ImageId, ImageCache>();
+
+    for (const { resource: r, bitmap } of await glyphSprites(spec)) {
+      const id = newImageId();
+
+      assets.set(id, { id, cf: r.cf, w: r.w, h: r.h, data: r.data });
+      cache.set(id, { bitmap });
+    }
+    return { spec, ids: [...assets.keys()], assets, cache };
+  },
+});
+
+// Ten transparent frames, one per digit: a number widget whose art comes later, from a font or
+// from PNGs dropped on the frames one at a time. The size is a placeholder — both paths bring
+// their own (replaceImageFx takes the file's, the generator the font cell's).
+const addNumberFx = attach({
+  source: $screen,
+  async effect(screen) {
+    const assets = new Map<ImageId, ImageAsset>();
+    const cache = new Map<ImageId, ImageCache>();
+
+    for (let i = 0; i < 10; i++) {
+      const r = await blankFrame(32, 48);
+      const id = newImageId();
+
+      assets.set(id, { id, cf: r.cf, w: r.w, h: r.h, data: r.data });
+      cache.set(id, { bitmap: r.bitmap });
+    }
+    return { screen, assets, cache, layer: newNumber([...assets.keys()]) };
   },
 });
 
@@ -353,11 +404,15 @@ sample({
   target: addWidgetFx,
 });
 sample({
+  clock: numberAdded,
+  target: addNumberFx,
+});
+sample({
   clock: slotAdded,
   target: addSlotFx,
 });
 sample({
-  clock: [addWidgetFx.doneData, addSlotFx.doneData],
+  clock: [addWidgetFx.doneData, addNumberFx.doneData, addSlotFx.doneData],
   filter: Boolean,
   fn: ({ screen, assets, layer }) => ({
     edit: (doc: Doc) => addLayer(withAssets(doc, assets), screen, layer),
@@ -365,16 +420,57 @@ sample({
   target: committed,
 });
 sample({
-  clock: [addWidgetFx.doneData, addSlotFx.doneData],
+  clock: [addWidgetFx.doneData, addNumberFx.doneData, addSlotFx.doneData],
   filter: Boolean,
   fn: ({ cache }) => cache,
   target: cachePatched,
 });
 sample({
-  clock: [addWidgetFx.doneData, addSlotFx.doneData],
+  clock: [addWidgetFx.doneData, addNumberFx.doneData, addSlotFx.doneData],
   filter: Boolean,
   fn: ({ layer }) => layer.id,
   target: select,
+});
+
+sample({
+  clock: glyphsRequested,
+  target: glyphsFx,
+});
+sample({
+  clock: glyphsFx.doneData,
+  filter: Boolean,
+  fn: ({ spec, ids, assets }) => ({
+    edit: (doc: Doc) => {
+      const l = findLayer(doc, spec.target);
+
+      if (!l || l.kind === "group" || l.kind === "raw") return doc;
+      // frames only: meta (source, accent flag, digit count) is the inspector's, and a
+      // regeneration must not reach over and change it
+      return patchLayer(
+        withAssets(doc, assets),
+        l.id,
+        (l.kind === "number" ? { glyphs: ids } : { frames: ids }) as Partial<Layer>,
+      );
+    },
+  }),
+  target: committed,
+});
+sample({
+  clock: glyphsFx.doneData,
+  filter: Boolean,
+  fn: ({ cache }) => cache,
+  target: cachePatched,
+});
+/** Hand the recipe to the resize, which re-renders rather than rescaling these frames. */
+sample({
+  clock: glyphsFx.doneData,
+  filter: Boolean,
+  fn: ({ spec }) => ({ layer: spec.target, spec }),
+  target: glyphSpecRemembered,
+});
+sample({
+  clock: glyphsFx.done,
+  target: glyphDialogClosed,
 });
 
 sample({
@@ -828,6 +924,8 @@ sample({
 sample({
   clock: [
     addWidgetFx.failData,
+    addNumberFx.failData,
+    glyphsFx.failData,
     addSlotFx.failData,
     addSlotMetricFx.failData,
     addAodFx.failData,

--- a/src/lib/modules/editor/model/edit.model.ts
+++ b/src/lib/modules/editor/model/edit.model.ts
@@ -51,7 +51,7 @@ import { $doc, committed, docLoaded } from "./doc.model";
 import { $screen, $sel, $selected, screenSet, select, selectionSet } from "./selection.model";
 import { $cache, cachePatched, glyphSpecRemembered } from "./assets.model";
 import { $sim } from "./sim.model";
-import { errored, glyphDialogClosed } from "./ui.model";
+import { errored } from "./ui.model";
 
 /** Figma-style alignment direction. */
 export type AlignDir = "left" | "hcenter" | "right" | "top" | "vcenter" | "bottom";
@@ -467,10 +467,6 @@ sample({
   filter: Boolean,
   fn: ({ spec }) => ({ layer: spec.target, spec }),
   target: glyphSpecRemembered,
-});
-sample({
-  clock: glyphsFx.done,
-  target: glyphDialogClosed,
 });
 
 sample({

--- a/src/lib/modules/editor/model/editor.model.ts
+++ b/src/lib/modules/editor/model/editor.model.ts
@@ -8,6 +8,7 @@
 //   assets.model     image assets, the decoded-bitmap cache, and pixel operations
 //   edit.model       every action on the layer tree
 //   io.model         open, create, import, export
+//   font-sprite.model  the "sprites from a font" generator: its dialog, form and preview
 //
 // Importing this module is what wires them up — the sample() calls in each file run on import.
 export * from "./doc.model";
@@ -17,3 +18,4 @@ export * from "./ui.model";
 export * from "./assets.model";
 export * from "./edit.model";
 export * from "./io.model";
+export * from "./font-sprite.model";

--- a/src/lib/modules/editor/model/font-sprite.model.ts
+++ b/src/lib/modules/editor/model/font-sprite.model.ts
@@ -1,0 +1,206 @@
+// The font-to-sprites generator: which widget it targets, the settings it holds, the font list it
+// offers and the preview it renders. The dialog is a view over these stores — it draws the preview
+// bitmaps and fires the events, and decides nothing itself.
+//
+// The sprites previewed here are NOT the ones that land in the document: `glyphsRequested` runs
+// the same pure `glyphSprites` again in edit.model, so the preview is a promise about the result
+// rather than the result itself.
+import { createEffect, createEvent, createStore, sample } from "effector";
+import {
+  DIGITS,
+  glyphSprites,
+  localFamilies,
+  registerFont,
+  type GlyphSpec,
+} from "../core/render/glyphs";
+import { FRAME_LABELS } from "../core/document/sources";
+import { findLayer } from "../core/document/edits";
+import type { NodeId } from "../core/document/doc";
+import { $doc } from "./doc.model";
+import { glyphsRequested } from "./edit.model";
+import { errored } from "./ui.model";
+
+/** One entry of the font picker: a CSS family list, and what to call it. */
+export type FontOption = { value: string; label: string };
+/** The dialog's form. `labelsText` is free-form — the labels are whitespace-separated. */
+export type GlyphForm = Omit<GlyphSpec, "labels"> & { labelsText: string };
+
+/** The families the app ships, always at the bottom of the picker. Spelled as CSS family lists,
+ *  since that is what a canvas font shorthand takes. */
+export const APP_FAMILIES: FontOption[] = [
+  { value: '"Geist Mono", ui-monospace, monospace', label: "Geist Mono (app)" },
+  { value: '"Instrument Serif", Georgia, serif', label: "Instrument Serif (display)" },
+  { value: "system-ui, sans-serif", label: "System sans" },
+  { value: "ui-monospace, monospace", label: "System mono" },
+];
+/** The nine CSS weights. A family that has fewer just snaps to its nearest. */
+export const WEIGHTS = [100, 200, 300, 400, 500, 600, 700, 800, 900];
+
+const FORM0: GlyphForm = {
+  family: APP_FAMILIES[0].value,
+  sizePx: 48,
+  weight: 500,
+  italic: false,
+  color: "#ffffff",
+  spacing: 0,
+  labelsText: DIGITS.join(" "),
+};
+
+export const labelsOf = (form: GlyphForm) => form.labelsText.split(/\s+/).filter(Boolean);
+const specOf = (form: GlyphForm): GlyphSpec => ({ ...form, labels: labelsOf(form) });
+
+// ---- stores ----
+/** null when closed, otherwise the layer whose frames the generator will replace. */
+export const $glyphDialog = createStore<NodeId | null>(null);
+export const $glyphForm = createStore<GlyphForm>(FORM0);
+export const $fontOptions = createStore<FontOption[]>(APP_FAMILIES);
+/** The strip the dialog draws, plus what the set costs in the file. */
+export const $glyphPreview = createStore<{
+  bitmaps: readonly ImageBitmap[];
+  w: number;
+  h: number;
+  bytes: number;
+} | null>(null);
+
+// ---- events ----
+export const glyphDialogOpened = createEvent<NodeId>();
+export const glyphDialogClosed = createEvent();
+export const glyphFormPatched = createEvent<Partial<GlyphForm>>();
+export const fontFilePicked = createEvent<File>();
+/** Ask for the machine's own font list — Chromium only, and behind a permission prompt. */
+export const installedFontsRequested = createEvent();
+export const glyphsGenerateRequested = createEvent();
+
+// ---- effects ----
+const previewFx = createEffect(async (form: GlyphForm) => ({
+  form,
+  sprites: await glyphSprites(specOf(form)),
+}));
+const registerFontFx = createEffect((file: File) => registerFont(file));
+const localFontsFx = createEffect(() => localFamilies());
+
+export const $localFontsPending = localFontsFx.pending;
+
+// ---- business logic ----
+sample({
+  clock: glyphDialogOpened,
+  target: $glyphDialog,
+});
+// Closed by the request the generator actually accepted, NOT by glyphsGenerateRequested: that
+// one is also what the target is read from below, and clearing it on the same clock would race
+// the read (declaration order decides who wins — it did, and the generate silently did nothing).
+sample({
+  clock: [glyphDialogClosed, glyphsRequested],
+  fn: () => null,
+  target: $glyphDialog,
+});
+/** What the widget being replaced has to hold: a value-indexed source fixes both the labels and
+ *  their order (index = value), anything else gets the ten digits. */
+sample({
+  clock: glyphDialogOpened,
+  source: $doc,
+  fn: (doc, id) => {
+    const l = doc ? findLayer(doc, id) : null;
+    const labels =
+      l && l.kind !== "group" && l.kind !== "raw"
+        ? (FRAME_LABELS[l.meta.source] ?? DIGITS)
+        : DIGITS;
+
+    return { labelsText: labels.join(" ") };
+  },
+  target: glyphFormPatched,
+});
+sample({
+  clock: glyphFormPatched,
+  source: $glyphForm,
+  fn: (form, patch) => ({ ...form, ...patch }),
+  target: $glyphForm,
+});
+
+// Preview: re-rendered on every change of the form, including the seeding above.
+sample({
+  clock: $glyphForm,
+  filter: (form) => labelsOf(form).length > 0,
+  target: previewFx,
+});
+sample({
+  clock: $glyphForm,
+  filter: (form) => labelsOf(form).length === 0,
+  fn: () => null,
+  target: $glyphPreview,
+});
+// Rasterizing is async (a font may still be loading), so a slow render can land after a newer
+// one — the form the render started from has to still be the current one. Reference equality is
+// enough: every patch replaces the object.
+sample({
+  clock: previewFx.doneData,
+  source: $glyphForm,
+  filter: (form, done) => done.form === form,
+  fn: (_, { sprites }) => ({
+    bitmaps: sprites.map((s) => s.bitmap),
+    w: sprites[0]?.resource.w ?? 0,
+    h: sprites[0]?.resource.h ?? 0,
+    bytes: sprites.reduce((n, s) => n + s.resource.data.length, 0),
+  }),
+  target: $glyphPreview,
+});
+
+// A font file the user picked goes to the top of the list and becomes the selection.
+sample({
+  clock: fontFilePicked,
+  target: registerFontFx,
+});
+sample({
+  clock: registerFontFx.done,
+  source: $fontOptions,
+  fn: (options, { params, result }) => [
+    { value: result, label: params.name },
+    ...options.filter((o) => o.value !== result),
+  ],
+  target: $fontOptions,
+});
+sample({
+  clock: registerFontFx.doneData,
+  fn: (family) => ({ family }),
+  target: glyphFormPatched,
+});
+sample({
+  clock: registerFontFx.fail,
+  fn: ({ params }) => `${params.name} is not a font the browser can read`,
+  target: errored,
+});
+
+// The installed families replace whatever was picked from a file — one source of truth in the
+// list at a time. An empty answer is a denied permission (or a browser without the API), which
+// is a normal outcome rather than a failure.
+sample({
+  clock: installedFontsRequested,
+  target: localFontsFx,
+});
+sample({
+  clock: localFontsFx.doneData,
+  filter: (families) => families.length > 0,
+  fn: (families) => [...families.map((f) => ({ value: `"${f}"`, label: f })), ...APP_FAMILIES],
+  target: $fontOptions,
+});
+sample({
+  clock: localFontsFx.doneData,
+  filter: (families) => families.length > 0,
+  fn: (families) => ({ family: `"${families[0]}"` }),
+  target: glyphFormPatched,
+});
+sample({
+  clock: localFontsFx.doneData,
+  filter: (families) => families.length === 0,
+  fn: () => "No access to installed fonts — upload a font file instead",
+  target: errored,
+});
+
+// Frames only: the accent flag and the data source are the inspector's own controls.
+sample({
+  clock: glyphsGenerateRequested,
+  source: { target: $glyphDialog, form: $glyphForm },
+  filter: ({ target, form }) => Boolean(target) && labelsOf(form).length > 0,
+  fn: ({ target, form }) => ({ target: target!, ...specOf(form) }),
+  target: glyphsRequested,
+});

--- a/src/lib/modules/editor/model/ui.model.ts
+++ b/src/lib/modules/editor/model/ui.model.ts
@@ -1,8 +1,6 @@
-// Editor chrome: which right-hand tab is open, whether the glyph generator is showing, and the
-// last error. Nothing here reads the document — the panels that do import these stores and drive
-// them with events; the one NodeId below is a dialog argument, not document state.
+// Editor chrome: which right-hand tab is open, and the last error to show. Nothing here knows
+// about the document — the panels that do import these stores and drive them with events.
 import { createEvent, createStore, sample } from "effector";
-import type { NodeId } from "../core/document/doc";
 
 // ---- stores ----
 /** Right-side panel tab. Driven by the `select` event rather than derived from the selection:
@@ -13,16 +11,11 @@ export const $err = createStore("");
 /** Keep a resize proportional. One flag for both ways in: the props panel's link toggle and a
  *  corner drag on the canvas (shift inverts it there, as everywhere else). */
 export const $lockAspect = createStore(true);
-/** The "sprites from a font" dialog: null when closed, otherwise the layer whose frames it will
- *  replace. Opened from that layer's own inspector. */
-export const $glyphDialog = createStore<NodeId | null>(null);
 
 // ---- events ----
 export const rightPanelSet = createEvent<"props" | "sim">();
 export const errored = createEvent<string>();
 export const lockAspectToggled = createEvent();
-export const glyphDialogOpened = createEvent<NodeId>();
-export const glyphDialogClosed = createEvent();
 
 // ---- business logic ----
 sample({
@@ -38,13 +31,4 @@ sample({
   source: $lockAspect,
   fn: (on) => !on,
   target: $lockAspect,
-});
-sample({
-  clock: glyphDialogOpened,
-  target: $glyphDialog,
-});
-sample({
-  clock: glyphDialogClosed,
-  fn: () => null,
-  target: $glyphDialog,
 });

--- a/src/lib/modules/editor/model/ui.model.ts
+++ b/src/lib/modules/editor/model/ui.model.ts
@@ -1,6 +1,8 @@
-// Editor chrome: which right-hand tab is open, and the last error to show. Nothing here knows
-// about the document — the panels that do import these stores and drive them with events.
+// Editor chrome: which right-hand tab is open, whether the glyph generator is showing, and the
+// last error. Nothing here reads the document — the panels that do import these stores and drive
+// them with events; the one NodeId below is a dialog argument, not document state.
 import { createEvent, createStore, sample } from "effector";
+import type { NodeId } from "../core/document/doc";
 
 // ---- stores ----
 /** Right-side panel tab. Driven by the `select` event rather than derived from the selection:
@@ -11,11 +13,16 @@ export const $err = createStore("");
 /** Keep a resize proportional. One flag for both ways in: the props panel's link toggle and a
  *  corner drag on the canvas (shift inverts it there, as everywhere else). */
 export const $lockAspect = createStore(true);
+/** The "sprites from a font" dialog: null when closed, otherwise the layer whose frames it will
+ *  replace. Opened from that layer's own inspector. */
+export const $glyphDialog = createStore<NodeId | null>(null);
 
 // ---- events ----
 export const rightPanelSet = createEvent<"props" | "sim">();
 export const errored = createEvent<string>();
 export const lockAspectToggled = createEvent();
+export const glyphDialogOpened = createEvent<NodeId>();
+export const glyphDialogClosed = createEvent();
 
 // ---- business logic ----
 sample({
@@ -31,4 +38,13 @@ sample({
   source: $lockAspect,
   fn: (on) => !on,
   target: $lockAspect,
+});
+sample({
+  clock: glyphDialogOpened,
+  target: $glyphDialog,
+});
+sample({
+  clock: glyphDialogClosed,
+  fn: () => null,
+  target: $glyphDialog,
 });

--- a/src/lib/modules/editor/pages/editor.svelte
+++ b/src/lib/modules/editor/pages/editor.svelte
@@ -6,6 +6,7 @@
   import { authModel } from "$lib/modules/auth/model";
   import { marketModel } from "$lib/modules/market/model";
   import PublishDialog from "../components/PublishDialog.svelte";
+  import GlyphsDialog from "../components/GlyphsDialog.svelte";
   import { bleModel } from "$lib/modules/device/model";
   import { renderDoc, type ResizePreview } from "../core/render/render";
   import { CENTER, SCREEN } from "../core/render/screen";
@@ -983,6 +984,7 @@
 </Dialog>
 
 <PublishDialog />
+<GlyphsDialog />
 
 <ShortcutsDialog open={helpOpen} onClose={() => (helpOpen = false)} />
 

--- a/src/lib/shared/components/icon/icon.svelte
+++ b/src/lib/shared/components/icon/icon.svelte
@@ -66,6 +66,8 @@
   import IconLink from "@tabler/icons-svelte/icons/link";
   import IconUnlink from "@tabler/icons-svelte/icons/unlink";
   import IconGripVertical from "@tabler/icons-svelte/icons/grip-vertical";
+  import IconUpload from "@tabler/icons-svelte/icons/upload";
+  import IconAbc from "@tabler/icons-svelte/icons/abc";
 
   // Central icon registry — the single place to retune an icon app-wide.
   // Keys are OUR semantic names (used at call sites); values are Tabler components.
@@ -139,6 +141,8 @@
     link: IconLink, // aspect-ratio lock: chain link, like Figma's constrain-proportions toggle
     unlink: IconUnlink,
     grip: IconGripVertical,
+    upload: IconUpload,
+    abc: IconAbc, // letters, not a generic list — the installed-fonts picker
   } as const;
 
   export type IconName = keyof typeof ICONS;

--- a/src/lib/shared/components/input/input.svelte
+++ b/src/lib/shared/components/input/input.svelte
@@ -52,11 +52,13 @@
 />
 
 <style>
+  /* same box as Button's default size, so a field and the button beside it line up */
   input {
     width: 100%;
-    height: 2.5rem;
-    padding: 0 0.75rem;
+    height: 1.875rem;
+    padding: 0 0.625rem;
     font: inherit;
+    font-size: 0.75rem;
     color: var(--color-text);
     background: oklch(from var(--color-text) l c h / 5%);
     border: 1px solid transparent;

--- a/src/lib/shared/components/select/select.svelte
+++ b/src/lib/shared/components/select/select.svelte
@@ -15,11 +15,13 @@
 </select>
 
 <style>
+  /* same box as Button's default size — see input/ */
   select {
     width: 100%;
-    height: 2.5rem;
-    padding: 0 2rem 0 0.75rem;
+    height: 1.875rem;
+    padding: 0 1.75rem 0 0.625rem;
     font: inherit;
+    font-size: 0.75rem;
     color: var(--color-text);
     background:
       no-repeat right 0.625rem center / 0.875rem

--- a/src/lib/shared/components/textarea/textarea.svelte
+++ b/src/lib/shared/components/textarea/textarea.svelte
@@ -14,8 +14,9 @@
 <style>
   textarea {
     width: 100%;
-    padding: 0.625rem 0.75rem;
+    padding: 0.5rem 0.625rem;
     font: inherit;
+    font-size: 0.75rem;
     color: var(--color-text);
     background: oklch(from var(--color-text) l c h / 5%);
     border: 1px solid transparent;

--- a/tests/editor-font-glyphs.browser.test.ts
+++ b/tests/editor-font-glyphs.browser.test.ts
@@ -158,6 +158,25 @@ test("resizing a generated set re-renders it from the font instead of scaling th
   expect(new Set(sizes(num.id)).size).toBe(1); // still one cell across the set
 });
 
+test("the dialog's own form drives the generator and closes on generate", async () => {
+  await load("glyphs-dialog");
+  const num = firstNumber();
+  const before = framesOf(num);
+
+  editorModel.glyphDialogOpened(num.id);
+  expect(editorModel.$glyphDialog.getState()).toBe(num.id);
+  // the form is seeded from the widget: a plain number wants the ten digits
+  expect(editorModel.$glyphForm.getState().labelsText).toBe(DIGITS.join(" "));
+  await until(() => Boolean(editorModel.$glyphPreview.getState())); // preview follows the form
+
+  editorModel.glyphFormPatched({ family: "monospace", sizePx: 24 });
+  editorModel.glyphsGenerateRequested();
+  await until(() => framesOf(byId(num.id))[0] !== before[0]);
+
+  expect(framesOf(byId(num.id))).toHaveLength(10);
+  expect(editorModel.$glyphDialog.getState()).toBeNull(); // and it closed itself
+});
+
 test("labels of different widths still share one cell", async () => {
   await load("glyphs-labels");
   const num = firstNumber();

--- a/tests/editor-font-glyphs.browser.test.ts
+++ b/tests/editor-font-glyphs.browser.test.ts
@@ -1,0 +1,171 @@
+// Regenerating a widget's sprites from a font. The point of the shared cell is that a number
+// widget draws its glyphs edge to edge — unequal sprite widths make the value jump around as it
+// changes — so what is checked here is that every sprite comes out the same size, whatever the
+// labels, and that the layer itself survives the swap.
+import { test, expect } from "vitest";
+import { findLayer } from "$lib/modules/editor/core/document/edits";
+import { framesOf, type Layer, type NodeId } from "$lib/modules/editor/core/document/doc";
+import { DIGITS } from "$lib/modules/editor/core/render/glyphs";
+import { editorModel } from "$lib/modules/editor/model";
+import url from "./__fixtures__/Digital__281__Metaball.bin?url";
+
+const doc = () => editorModel.$doc.getState()!;
+const byId = (id: NodeId) => findLayer(doc(), id)!;
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+const load = async (label: string) => {
+  const buf = await fetch(url).then((r) => r.arrayBuffer());
+
+  await new Promise<void>((resolve) => {
+    const unwatch = editorModel.loadDone.watch(() => {
+      unwatch();
+      resolve();
+    });
+
+    editorModel.loadRequested({ buf, label });
+  });
+};
+
+async function until(cond: () => boolean) {
+  for (let i = 0; i < 200 && !cond(); i++) await sleep(5);
+  expect(cond()).toBe(true);
+}
+
+/** The first number widget on the main screen, however deep it sits. */
+function firstNumber(): Layer {
+  const walk = (ls: readonly Layer[]): Layer | null => {
+    for (const l of ls) {
+      if (l.kind === "number") return l;
+      const kids = l.kind === "group" ? l.children : l.kind === "raw" ? (l.children ?? []) : [];
+      const hit = walk(kids);
+
+      if (hit) return hit;
+    }
+    return null;
+  };
+
+  return walk(doc().screens[0].layers)!;
+}
+
+const spec = (
+  target: NodeId,
+  over: Partial<Parameters<typeof editorModel.glyphsRequested>[0]> = {},
+) => ({
+  target,
+  labels: DIGITS,
+  family: "monospace",
+  sizePx: 40,
+  weight: 500,
+  italic: false,
+  color: "#ffffff",
+  spacing: 0,
+  ...over,
+});
+
+/** The decoded size of every frame a layer draws. */
+const sizes = (id: NodeId) =>
+  framesOf(byId(id)).map((f) => {
+    const a = doc().images.get(f)!;
+
+    return `${a.w}x${a.h}`;
+  });
+
+test("a number's ten glyphs are replaced by equal-size sprites from a font", async () => {
+  await load("glyphs");
+  const num = firstNumber();
+  const before = framesOf(num);
+
+  expect(before.length).toBe(10);
+  editorModel.glyphsRequested(spec(num.id));
+  await until(() => framesOf(byId(num.id))[0] !== before[0]);
+
+  const after = framesOf(byId(num.id));
+
+  expect(byId(num.id).kind).toBe("number"); // same layer, new pixels
+  expect(after).toHaveLength(10);
+  expect(new Set(sizes(num.id)).size).toBe(1); // one cell for all ten — nothing jitters
+  expect(doc().images.get(after[8])!.data.length).toBeGreaterThan(0);
+
+  // the file still builds with the generated sprites in it
+  expect((await editorModel.buildCurrentBin()).byteLength).toBeGreaterThan(0);
+});
+
+test("spacing widens the cell, and meta is left alone", async () => {
+  await load("glyphs-spacing");
+  const num = firstNumber();
+
+  const first = framesOf(num)[0];
+
+  editorModel.glyphsRequested(spec(num.id, { spacing: 0 }));
+  await until(() => framesOf(byId(num.id))[0] !== first);
+  const tight = doc().images.get(framesOf(byId(num.id))[0])!.w;
+  const second = framesOf(byId(num.id))[0];
+
+  editorModel.glyphsRequested(spec(num.id, { spacing: 10 }));
+  await until(() => framesOf(byId(num.id))[0] !== second);
+  expect(doc().images.get(framesOf(byId(num.id))[0])!.w).toBe(tight + 10);
+  expect(new Set(sizes(num.id)).size).toBe(1);
+
+  // regeneration touches frames only — the accent flag and the source stay the inspector's
+  const l = byId(num.id);
+
+  expect(l.kind !== "group" && l.kind !== "raw" && l.meta).toEqual(
+    num.kind !== "group" && num.kind !== "raw" && num.meta,
+  );
+});
+
+test("an empty number widget can be created and then filled from a font", async () => {
+  await load("glyphs-empty");
+  const before = doc().screens[0].layers.length;
+
+  editorModel.numberAdded();
+  await until(() => doc().screens[0].layers.length === before + 1);
+  const id = editorModel.$sel.getState()!;
+
+  expect(byId(id).kind).toBe("number");
+  expect(framesOf(byId(id))).toHaveLength(10); // one blank per digit, no file picked
+  const blank = framesOf(byId(id))[0];
+
+  editorModel.glyphsRequested(spec(id, { sizePx: 32 }));
+  await until(() => framesOf(byId(id))[0] !== blank);
+  expect(framesOf(byId(id))).toHaveLength(10);
+  expect(new Set(sizes(id)).size).toBe(1);
+});
+
+test("resizing a generated set re-renders it from the font instead of scaling the pixels", async () => {
+  await load("glyphs-resize");
+  const num = firstNumber();
+  const before = framesOf(num)[0];
+
+  editorModel.glyphsRequested(spec(num.id, { sizePx: 20 }));
+  await until(() => framesOf(byId(num.id))[0] !== before);
+  const frame = framesOf(byId(num.id))[0];
+  const small = doc().images.get(frame)!;
+
+  editorModel.resizeImageRequested({ layer: num.id, w: small.w * 2, h: small.h * 2 });
+  await until(() => doc().images.get(frame)!.h > small.h);
+
+  const big = doc().images.get(frame)!;
+
+  // the height follows the drag; the font's own metrics decide the last pixel or two
+  expect(Math.abs(big.h - small.h * 2)).toBeLessThanOrEqual(2);
+
+  // re-rendered, not rescaled: the resize path that scales bitmaps pins an `original` in the
+  // cache and leaves `data` stale for flushAssets — this one writes fresh bytes and no original
+  expect(editorModel.$cache.getState().get(frame)?.original).toBeUndefined();
+  expect(big.data).not.toEqual(small.data);
+  expect(big.w).toBeGreaterThan(small.w);
+  expect(new Set(sizes(num.id)).size).toBe(1); // still one cell across the set
+});
+
+test("labels of different widths still share one cell", async () => {
+  await load("glyphs-labels");
+  const num = firstNumber();
+
+  // "Sun" and "Wed" are wider than "Fri" in most faces — the widest wins for all seven
+  editorModel.glyphsRequested(
+    spec(num.id, { labels: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] }),
+  );
+  await until(() => framesOf(byId(num.id)).length === 7);
+  expect(new Set(sizes(num.id)).size).toBe(1);
+});


### PR DESCRIPTION
Closes #15.

A number widget needed ten PNGs before you could even add one. The rasterizer that makes them was already in the repo — written for the Facer importer — so most of this is a move rather than new code.

### What changed

- **`core/render/glyphs.ts`** — `glyphCell` / `renderGlyphs` lifted out of `import/facer/text.ts`, plus `registerFont` (a `FontFace` from a picked file), `localFamilies` (`queryLocalFonts`, empty when it's unavailable or denied) and `glyphBytes` (the real LZ4'd cost). `resourceFromCanvas` moved to `render/pixels.ts`; the importers call it through their old `encodeCanvas`.
- **`+ → Number`** creates the widget empty — ten transparent frames, no file picker.
- **"regenerate from a font"** in the inspector, for a number's ten digits and for the labels of a value-indexed source (weekday, month, AM/PM). Font from an uploaded `ttf/otf/woff`, an installed family, or one the app ships; size, weight, italic, colour + hex, tracking; live preview of the strip with its encoded size.
- **Resize re-renders.** How each set was rasterized is remembered per session, so dragging a corner re-runs the font at the new point size instead of interpolating the bitmaps up. No spec (art that never came from a font, or a reloaded session) → the old rescale path, unchanged.

The equal-width cell is a correctness thing, not polish: `drawDigits` packs the glyphs edge to edge, so unequal sprite widths make the value jitter as it changes — which is exactly the report in the issue's comment.

### Along the way

- `input` / `select` / `textarea` now take the default button's height, so a field and the button next to it line up.
- The Facer importer's font fallback was `"bold sans-serif"` — not a valid family inside a font shorthand, so the whole `ctx.font` string was rejected and every measurement quietly fell back to 10px.

### Not in scope

Standalone glyphs (`:`, `°`, `%`) as their own action — the model already replaces any widget's frames, it just has no entry point yet. The hue-slider complaint in the issue thread is a separate bug.

`tests/editor-font-glyphs.browser.test.ts` covers the equal cell, tracking, the empty-widget path and the resize re-render. 156 tests, `check` and `lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015YaTG3JfKYXVSJaqd9Te6W