### PR TITLE
Measure the glyph cell instead of guessing its descender

### DIFF
--- a/src/lib/modules/editor/core/import/facer/index.ts
+++ b/src/lib/modules/editor/core/import/facer/index.ts
@@ -478,11 +478,11 @@ export async function facerToFace(files: File[]): Promise<{ face: Face; skipped:
     const color = rgba(argb(ambient ? (l.low_power_color ?? l.color) : l.color));
     const labelsOf = (p: Part) => (!isLive(p) ? [p.text] : p.type === "select" ? p.labels : DIGITS);
     // one vertical metric across every part so the whole row shares a baseline
-    const tall = glyphCell(cls.parts.flatMap(labelsOf), font, sizePx);
+    const tall = glyphCell(cls.parts.flatMap(labelsOf), font);
     const sprites = new Map<string, number[]>(); // hour and minute share one digit set
     const cellOf = async (p: Part) => {
       const labels = labelsOf(p);
-      const cell = { ...glyphCell(labels, font, sizePx), h: tall.h, base: tall.base };
+      const cell = { ...glyphCell(labels, font), h: tall.h, base: tall.base };
       const key = labels.join("|");
 
       if (!sprites.has(key)) {

--- a/src/lib/modules/editor/core/render/glyphs.ts
+++ b/src/lib/modules/editor/core/render/glyphs.ts
@@ -33,7 +33,7 @@ export const ensureFont = (font: string) => document.fonts.load(font).catch(() =
 // edge (`cx += b.width` in drawDigits), so unequal widths make the value jitter as it changes.
 // `spacing` widens the cell without moving the glyph — tracking, since there is nothing between
 // two sprites to space out.
-export function glyphCell(labels: string[], font: string, sizePx: number, spacing = 0): Cell {
+export function glyphCell(labels: string[], font: string, spacing = 0): Cell {
   const meas = new OffscreenCanvas(4, 4).getContext("2d")!;
 
   meas.font = font;
@@ -45,8 +45,12 @@ export function glyphCell(labels: string[], font: string, sizePx: number, spacin
     const m = meas.measureText(s);
 
     w = Math.max(w, Math.ceil(m.width));
-    asc = Math.max(asc, m.actualBoundingBoxAscent || sizePx * 0.75);
-    desc = Math.max(desc, m.actualBoundingBoxDescent || sizePx * 0.25);
+    // measured, never guessed from the point size: digits have no descender, so a guessed one
+    // fires or doesn't depending on whether the browser reports an exact 0 — which differs
+    // between platforms and even between sizes of the same face, and makes the cell's height
+    // jump by a quarter of the point size instead of following it
+    asc = Math.max(asc, m.actualBoundingBoxAscent || 0);
+    desc = Math.max(desc, m.actualBoundingBoxDescent || 0);
   }
   const base = Math.ceil(asc) + 2;
 
@@ -85,6 +89,33 @@ export type GlyphSpec = {
   spacing: number;
 };
 
+/** The point size whose cell comes out `h` tall. One ratio step misses by up to a few pixels —
+ *  the cell rounds ascent and descent up separately, so its height isn't proportional to the
+ *  point size — so the ratio is re-applied against a fresh measurement until it lands. Measuring
+ *  is measureText only, no rasterizing. */
+export async function sizeForHeight(spec: GlyphSpec, h: number): Promise<number> {
+  const labels = spec.labels.filter((s) => s.length);
+  let size = spec.sizePx,
+    best = size,
+    err = Infinity;
+
+  for (let i = 0; i < 6; i++) {
+    const font = fontOf(spec.family, size, spec.weight, spec.italic);
+
+    await ensureFont(font);
+    const cell = glyphCell(labels, font, spec.spacing);
+    const off = Math.abs(cell.h - h);
+
+    if (off < err) {
+      err = off;
+      best = size;
+    }
+    if (!off) break;
+    size = Math.max(1, (size * (h - CELL_PAD)) / Math.max(1, cell.h - CELL_PAD));
+  }
+  return best;
+}
+
 /** The sprites a spec describes, encoded and decoded: what the generator stores and what a resize
  *  re-renders. Empty labels are dropped — the caller's text field is free-form. */
 export async function glyphSprites(spec: GlyphSpec, cf = GLYPH_CF) {
@@ -92,7 +123,7 @@ export async function glyphSprites(spec: GlyphSpec, cf = GLYPH_CF) {
   const font = fontOf(spec.family, spec.sizePx, spec.weight, spec.italic);
 
   await ensureFont(font);
-  const cell = glyphCell(labels, font, spec.sizePx, spec.spacing);
+  const cell = glyphCell(labels, font, spec.spacing);
 
   return Promise.all(
     renderGlyphs(labels, font, spec.color, cell).map(async (canvas) => ({

--- a/src/lib/modules/editor/model/assets.model.ts
+++ b/src/lib/modules/editor/model/assets.model.ts
@@ -14,7 +14,7 @@ import {
   invertAsset,
   resourceFromFile,
 } from "../core/render/pixels";
-import { CELL_PAD, glyphSprites, type GlyphSpec } from "../core/render/glyphs";
+import { glyphSprites, sizeForHeight, type GlyphSpec } from "../core/render/glyphs";
 import {
   framesOf,
   type Doc,
@@ -210,9 +210,9 @@ const resizeImageFx = attach({
     const spec = glyphSpecs.get(l.id);
 
     if (spec && spec.labels.length === frames.length) {
-      // the cell's padding doesn't scale, so it comes off both heights before the ratio
-      const k = Math.max(0.05, (th - CELL_PAD) / Math.max(1, first.h - CELL_PAD));
-      const next = { ...spec, sizePx: spec.sizePx * k, spacing: spec.spacing * k };
+      const sizePx = await sizeForHeight(spec, th);
+      const k = sizePx / Math.max(0.05, spec.sizePx);
+      const next = { ...spec, sizePx, spacing: spec.spacing * k };
       const sprites = await glyphSprites(next);
 
       frames.forEach((id, i) => {


### PR DESCRIPTION
`editor-font-glyphs.browser.test.ts > resizing a generated set re-renders it from the font` failed on CI but passed on macOS.

## Root cause

`glyphCell` guessed the vertical metrics when a label reported none:

```ts
asc = Math.max(asc, m.actualBoundingBoxAscent || sizePx * 0.75);
desc = Math.max(desc, m.actualBoundingBoxDescent || sizePx * 0.25);
```

Digits have no descender, so whether that fallback fired came down to the browser reporting an exact zero. Chromium on Linux reports one at 20px and a hair above zero at 44px: the cell came out 24px tall at 20px (fallback on) and 37px at 44px (fallback off). The cell's height jumped by a quarter of the point size instead of following it, so a resize to 48px landed 11px short of the drag. macOS fonts report an exact zero at every size, which is why it only ever failed on CI.

## Fix

- Take the metrics as measured. `glyphCell`'s `sizePx` parameter is only there for the guess, so it goes.
- `sizeForHeight(spec, h)` picks the point size for a target height by re-measuring (`measureText` only, no rasterizing) instead of one ratio step over rounded heights — that step missed by up to 3px on macOS fonts alone, against the test's ±2 tolerance.

## Verification

- `mcr.microsoft.com/playwright:v1.61.1-noble` (CI's chromium and Linux fonts): 38 files / 160 tests green.
- A throwaway probe over 5 families × 6 sizes × 4 scale factors: worst height error 1px, down from 11px. The remaining ±1 is inherent — no integer point size hits those heights exactly.
- Locally: `lint`, `format:check`, `check` (0 errors), 159 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YX75MbJxUKP3M5Dwqzk9HP