### PR TITLE
Start the AOD screen as a copy of the dial

### DIFF
--- a/src/lib/modules/editor/model/edit.model.ts
+++ b/src/lib/modules/editor/model/edit.model.ts
@@ -2,6 +2,7 @@
 // pure `Doc -> Doc` edit handed to `committed`, so the history and the "what changed" logic stay
 // in one place — this file only decides which edit runs and what ends up selected.
 import { attach, createEffect, createEvent, createStore, sample } from "effector";
+import { TAG } from "../core/format";
 import { PREVIEW, SCREEN } from "../core/render/screen";
 import { renderDoc } from "../core/render/render";
 import { blankFrame, opaqueBlack, resourceFromFile } from "../core/render/pixels";
@@ -222,9 +223,10 @@ const addSlotFx = attach({
   },
 });
 
-// The AOD screen starts out the way every screen in the corpus does: its own preview thumbnail
-// (regenPreviewAssets refreshes it on save) over a black background. Async because both are
-// encoded images, same as adding a widget.
+// The AOD screen starts as a copy of the main dial, so dimming the face is editing down, not
+// rebuilding from black. It still gets its own preview thumbnail (regenPreviewAssets refreshes
+// it on save — sharing main's would overwrite one with the other); the copied layers get fresh
+// ids but share the dial's assets, same as duplicating a layer.
 const addAodFx = attach({
   source: $doc,
   async effect(doc) {
@@ -239,9 +241,19 @@ const addAodFx = attach({
       return id;
     };
     const preview = await add(await opaqueBlack(PREVIEW, PREVIEW));
-    const background = await add(await opaqueBlack(SCREEN, SCREEN));
+    const dial = (doc.screens.find((s) => s.kind === "main")?.layers ?? [])
+      .filter((l) => !(l.kind === "raw" && l.tag === TAG.preview))
+      .map(cloneLayer);
+    // a copied dial brings its own background, so the corpus-shape black one (and its asset) is
+    // only built for a face with nothing to copy — the bg id is a dummy when the layer is dropped
+    let screen = blankScreen(
+      "aod",
+      preview,
+      dial.length ? preview : await add(await opaqueBlack(SCREEN, SCREEN)),
+    );
 
-    return { assets, cache, screen: blankScreen("aod", preview, background) };
+    if (dial.length) screen = { ...screen, layers: [screen.layers[0], ...dial] };
+    return { assets, cache, screen };
   },
 });
 

--- a/tests/editor-aod.browser.test.ts
+++ b/tests/editor-aod.browser.test.ts
@@ -2,6 +2,7 @@
 // added. The added screen has to survive a build/parse round trip as a real 0x22 screen.
 import { test, expect, vi } from "vitest";
 import { parseBin, TAG } from "$lib/modules/editor/core/format";
+import { framesOf } from "$lib/modules/editor/core/document/doc";
 import { editorModel } from "$lib/modules/editor/model";
 
 const doc = () => editorModel.$doc.getState()!;
@@ -28,8 +29,13 @@ test("a new face can be given an AOD screen, and it round trips", async () => {
 
   // editing it is the point, so the editor switches to it
   expect(editorModel.$screen.getState()).toBe("aod");
-  // same shape every corpus screen has: a preview thumbnail over a background
+  // the dial is copied wholesale (here: just its background), under the screen's own preview
   expect(aod()!.layers.map((l) => l.kind)).toEqual(["raw", "image"]);
+  const mainBg = doc().screens.find((s) => s.kind === "main")!.layers[1];
+  const aodBg = aod()!.layers[1];
+
+  expect(aodBg.id).not.toBe(mainBg.id); // fresh ids, like any duplicate
+  expect(framesOf(aodBg)).toEqual(framesOf(mainBg)); // sharing the dial's assets
   // its own preview asset, not the main screen's — regen would otherwise overwrite one with the other
   const previewOf = (kind: "main" | "aod") => {
     const pv = doc().screens.find((s) => s.kind === kind)!.layers[0];


### PR DESCRIPTION
Adding an AOD screen now clones the main screen's layers (fresh ids, shared assets — same mechanics as duplicating a layer) instead of starting from a blank black screen, so dimming the face is editing down rather than rebuilding up. The screen still gets its own preview thumbnail; the corpus-shape black background is only built for a face with nothing to copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EtnDpyJhWfxU7YjQNFUMu1