### PR TITLE
Let a progress ring be resized, gapped and given a bitmap

### DIFF
--- a/src/lib/modules/editor/components/props/frame-thumb.svelte
+++ b/src/lib/modules/editor/components/props/frame-thumb.svelte
@@ -46,7 +46,11 @@
     <Icon name="download" size={14} />
   </button>
   <!-- a transparent frame in a value-indexed set = the widget blinks off on that value -->
-  <button title="Clear — transparent frame" onclick={() => clearImageRequested({ id })} class="dl-btn clear">
+  <button
+    title="Clear — transparent frame"
+    onclick={() => clearImageRequested({ id })}
+    class="dl-btn clear"
+  >
     <Icon name="eraser" size={14} />
   </button>
 </div>

--- a/src/lib/modules/editor/components/props/frames.svelte
+++ b/src/lib/modules/editor/components/props/frames.svelte
@@ -15,6 +15,7 @@
     replaceImageRequested,
     frameMoved,
     glyphDialogOpened,
+    ringImageAdded,
   } = editorModel;
 
   // native HTML5 drag & drop over the frame list, same shape as TreePanel's layer reorder
@@ -105,6 +106,30 @@
   </div>
 {/if}
 
+<!-- A ring is the one widget that draws with no art at all (the stroked 0x5a fallback), so it is
+     also the one that has nothing to click to give it some. Once it has a bitmap it clips to the
+     filled sector like any 0x5b ring, and the thumbnail above takes over. -->
+{#if layer.kind === "ring" && !images.length}
+  <div>
+    <span class="muted-label">ring art</span>
+    <label class="pick">
+      <Icon name="image-plus" size={14} />
+      use a ring bitmap
+      <input
+        type="file"
+        accept="image/*"
+        hidden
+        onchange={(e) => {
+          const file = e.currentTarget.files?.[0];
+
+          if (file) ringImageAdded({ id: layer.id, file });
+        }}
+      />
+    </label>
+    <p class="hint-xs">a full ring, drawn at 100% — the watch clips it to the filled sector</p>
+  </div>
+{/if}
+
 <!-- A set whose contents are spelled out by the format — the ten digits of a number, the labels
      of a value-indexed source — can be rasterized from a font instead of drawn by hand. A plain
      image qualifies too: one label makes a static text sprite (the only way to put a string the
@@ -173,6 +198,20 @@
     display: flex;
     flex-wrap: wrap;
     gap: 0.5rem;
+  }
+  /* a file input has to be a label, so it can't be the shared Button — same chrome, by hand */
+  .pick {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    padding: 0.375rem 0.625rem;
+    border: 1px solid oklch(from var(--color-text) l c h / 12%);
+    border-radius: var(--border-radius);
+    cursor: pointer;
+
+    &:hover {
+      background: oklch(from var(--color-text) l c h / 6%);
+    }
   }
   .thumb-cap {
     font-size: 0.625rem;

--- a/src/lib/modules/editor/components/props/frames.svelte
+++ b/src/lib/modules/editor/components/props/frames.svelte
@@ -20,6 +20,7 @@
 
   // native HTML5 drag & drop over the frame list, same shape as TreePanel's layer reorder
   let dragIdx = $state<number | null>(null);
+  let ringFile = $state<HTMLInputElement | null>(null);
   let dropIdx = $state<number | null>(null);
 
   // a fresh layer object arrives on every edit, so plain deriveds are enough here
@@ -112,20 +113,22 @@
 {#if layer.kind === "ring" && !images.length}
   <div>
     <span class="muted-label">ring art</span>
-    <label class="pick">
+    <!-- hidden input + a real Button, same as the tree panel's own add-image control -->
+    <input
+      bind:this={ringFile}
+      type="file"
+      accept="image/*"
+      hidden
+      onchange={(e) => {
+        const file = e.currentTarget.files?.[0];
+
+        if (file) ringImageAdded({ id: layer.id, file });
+      }}
+    />
+    <Button kind="secondary" onClick={() => ringFile?.click()}>
       <Icon name="image-plus" size={14} />
       use a ring bitmap
-      <input
-        type="file"
-        accept="image/*"
-        hidden
-        onchange={(e) => {
-          const file = e.currentTarget.files?.[0];
-
-          if (file) ringImageAdded({ id: layer.id, file });
-        }}
-      />
-    </label>
+    </Button>
     <p class="hint-xs">a full ring, drawn at 100% — the watch clips it to the filled sector</p>
   </div>
 {/if}
@@ -198,20 +201,6 @@
     display: flex;
     flex-wrap: wrap;
     gap: 0.5rem;
-  }
-  /* a file input has to be a label, so it can't be the shared Button — same chrome, by hand */
-  .pick {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.375rem;
-    padding: 0.375rem 0.625rem;
-    border: 1px solid oklch(from var(--color-text) l c h / 12%);
-    border-radius: var(--border-radius);
-    cursor: pointer;
-
-    &:hover {
-      background: oklch(from var(--color-text) l c h / 6%);
-    }
   }
   .thumb-cap {
     font-size: 0.625rem;

--- a/src/lib/modules/editor/components/props/geometry.svelte
+++ b/src/lib/modules/editor/components/props/geometry.svelte
@@ -3,8 +3,9 @@
   import { Slider } from "$lib/shared/components/slider";
   import { Icon, type IconName } from "$lib/shared/components/icon";
   import { framesOf, isPlaced, type Frame, type Layer } from "../../core/document/doc";
-  import type { ArcSpec } from "../../core/render/arc";
-  import { CENTER, SCREEN } from "../../core/render/screen";
+  import { FULL_BLEED_R, type ArcSpec } from "../../core/render/arc";
+  import { ringRadius } from "../../core/document/edits";
+  import { CENTER } from "../../core/render/screen";
   import { editorModel } from "../../model";
   import type { AlignDir } from "../../model/edit.model";
   import { num, set } from "./patch";
@@ -15,6 +16,7 @@
     $lockAspect: lockAspect,
     lockAspectToggled,
     resizeImageRequested,
+    ringResized,
     adjustImageRequested,
     alignRequested,
   } = editorModel;
@@ -46,25 +48,16 @@
   const ring = $derived(layer.kind === "ring" ? layer : null);
 
   // A ring with art is sized by its bitmap, like any other widget (the w/h block below); one
-  // without has no pixels at all — the diameter lives in the 0x5a spec, with meta.w/h as the
-  // renderer's fallback, so both move together and the ring grows around its own centre.
-  const ringR = $derived(ring ? ring.spec.radius || Math.round(ring.meta.w / 2) || 60 : 0);
+  // without has no pixels at all — its size is the 0x5a spec, so the field asks the model for the
+  // same factor a corner drag would, rather than rebuilding the ring here.
+  const ringR = $derived(ring ? ringRadius(ring) : 0);
   const bareRing = $derived(ring && !ring.frames.length ? ring : null);
 
   const setSpec = (patch: Partial<ArcSpec>) =>
     ring && set(ring.id, { spec: { ...ring.spec, ...patch } } as Partial<Layer>);
 
-  function setRingSize(d: number) {
-    if (!ring) return;
-    const r = Math.max(2, Math.round(d / 2));
-
-    set(ring.id, {
-      spec: { ...ring.spec, radius: r },
-      meta: { ...ring.meta, w: 2 * r, h: 2 * r },
-      x: ring.x + ringR - r,
-      y: ring.y + ringR - r,
-    } as Partial<Layer>);
-  }
+  const setRingSize = (d: number) =>
+    ring && ringResized({ layer: ring.id, kw: d / (2 * ringR), kh: d / (2 * ringR) });
 
   // size of the widget's first frame — the asset IS the widget's size, there's no draw-time
   // scale in the format, so resizing rescales the pixels (see assets.model)
@@ -179,7 +172,7 @@
       <Input
         type="number"
         min={4}
-        max={SCREEN}
+        max={2 * (FULL_BLEED_R - 1)}
         value={String(ringR * 2)}
         onChange={(v) => setRingSize(num(v))}
       />

--- a/src/lib/modules/editor/components/props/geometry.svelte
+++ b/src/lib/modules/editor/components/props/geometry.svelte
@@ -3,7 +3,8 @@
   import { Slider } from "$lib/shared/components/slider";
   import { Icon, type IconName } from "$lib/shared/components/icon";
   import { framesOf, isPlaced, type Frame, type Layer } from "../../core/document/doc";
-  import { CENTER } from "../../core/render/screen";
+  import type { ArcSpec } from "../../core/render/arc";
+  import { CENTER, SCREEN } from "../../core/render/screen";
   import { editorModel } from "../../model";
   import type { AlignDir } from "../../model/edit.model";
   import { num, set } from "./patch";
@@ -42,6 +43,28 @@
   const placed = $derived(isPlaced(layer) ? layer : null);
   const frame = $derived(layer.kind === "group" ? layer.frame : null);
   const hand = $derived(layer.kind === "hand" ? layer : null);
+  const ring = $derived(layer.kind === "ring" ? layer : null);
+
+  // A ring with art is sized by its bitmap, like any other widget (the w/h block below); one
+  // without has no pixels at all — the diameter lives in the 0x5a spec, with meta.w/h as the
+  // renderer's fallback, so both move together and the ring grows around its own centre.
+  const ringR = $derived(ring ? ring.spec.radius || Math.round(ring.meta.w / 2) || 60 : 0);
+  const bareRing = $derived(ring && !ring.frames.length ? ring : null);
+
+  const setSpec = (patch: Partial<ArcSpec>) =>
+    ring && set(ring.id, { spec: { ...ring.spec, ...patch } } as Partial<Layer>);
+
+  function setRingSize(d: number) {
+    if (!ring) return;
+    const r = Math.max(2, Math.round(d / 2));
+
+    set(ring.id, {
+      spec: { ...ring.spec, radius: r },
+      meta: { ...ring.meta, w: 2 * r, h: 2 * r },
+      x: ring.x + ringR - r,
+      y: ring.y + ringR - r,
+    } as Partial<Layer>);
+  }
 
   // size of the widget's first frame — the asset IS the widget's size, there's no draw-time
   // scale in the format, so resizing rescales the pixels (see assets.model)
@@ -90,13 +113,13 @@
 {/if}
 {#if placed && !frame}
   <div class="row">
-    <span class="field-label">x</span>
+    <span class="field-label w-md">x</span>
     <Input
       type="number"
       value={String(placed.x)}
       onInput={(v) => set(layer.id, { x: num(v) } as Partial<Layer>)}
     />
-    <span class="field-label">y</span>
+    <span class="field-label w-md">y</span>
     <Input
       type="number"
       value={String(placed.y)}
@@ -106,7 +129,7 @@
 {/if}
 {#if resSize}
   <div class="row">
-    <span class="field-label">w</span>
+    <span class="field-label w-md">w</span>
     <Input
       type="number"
       min={1}
@@ -115,7 +138,7 @@
       onChange={(v) =>
         resize(num(v), $lockAspect ? Math.round((num(v) * resSize.h) / resSize.w) : resSize.h)}
     />
-    <span class="field-label">h</span>
+    <span class="field-label w-md">h</span>
     <Input
       type="number"
       min={1}
@@ -149,21 +172,55 @@
     </div>
   {/each}
 {/if}
+{#if ring}
+  <div class="row">
+    {#if bareRing}
+      <span class="field-label w-md">size</span>
+      <Input
+        type="number"
+        min={4}
+        max={SCREEN}
+        value={String(ringR * 2)}
+        onChange={(v) => setRingSize(num(v))}
+      />
+    {/if}
+    <span class="field-label w-md">stroke</span>
+    <Input
+      type="number"
+      min={1}
+      value={String(ring.spec.width)}
+      onInput={(v) => setSpec({ width: Math.max(1, num(v)) })}
+    />
+  </div>
+  <div class="row">
+    <span class="field-label w-md">start</span>
+    <Input
+      type="number"
+      value={String(ring.spec.start)}
+      onInput={(v) => setSpec({ start: num(v) })}
+    />
+    <span class="field-label w-md">end</span>
+    <Input type="number" value={String(ring.spec.end)} onInput={(v) => setSpec({ end: num(v) })} />
+  </div>
+  <!-- the gap an icon sits in: start after 0 and end before 360 leaves the rest of the circle
+       empty, and the fill still runs the whole way from start to end -->
+  <p class="hint-xs">degrees clockwise from 12 o'clock — 20 → 340 leaves a 40° gap at the top</p>
+{/if}
 {#if frame}
   <div class="row">
-    <span class="field-label">x</span>
+    <span class="field-label w-md">x</span>
     <Input type="number" value={String(frame.x)} onInput={(v) => setFrame({ x: num(v) })} />
-    <span class="field-label">y</span>
+    <span class="field-label w-md">y</span>
     <Input type="number" value={String(frame.y)} onInput={(v) => setFrame({ y: num(v) })} />
   </div>
   <div class="row">
-    <span class="field-label">w</span>
+    <span class="field-label w-md">w</span>
     <Input type="number" value={String(frame.w)} onInput={(v) => setFrame({ w: num(v) })} />
-    <span class="field-label">h</span>
+    <span class="field-label w-md">h</span>
     <Input type="number" value={String(frame.h)} onInput={(v) => setFrame({ h: num(v) })} />
   </div>
   <div class="row">
-    <span class="field-label">align</span>
+    <span class="field-label w-md">align</span>
     <div class="btn-group">
       {#each FLEX_ALIGN as [main, iconName, title] (main)}
         <button
@@ -188,7 +245,7 @@
       value={String(hand.pivotX)}
       onInput={(v) => set(layer.id, { pivotX: num(v) } as Partial<Layer>)}
     />
-    <span class="field-label w-sm">y</span>
+    <span class="field-label w-md">y</span>
     <Input
       type="number"
       value={String(hand.pivotY)}

--- a/src/lib/modules/editor/components/props/source.svelte
+++ b/src/lib/modules/editor/components/props/source.svelte
@@ -19,6 +19,7 @@
     FRAME_LABELS,
     ID_LABELS,
   } from "../../core/document/sources";
+  import type { ArcSpec } from "../../core/render/arc";
   import { slotBindingOf } from "../../core/document/edits";
   import { SLOT_METRIC_CHOICES } from "../../core/document/factory";
   import { editorModel } from "../../model";
@@ -68,6 +69,9 @@
   // its baked color, so this works on any art.
   const setAccent = (on: boolean) =>
     meta && set(layer.id, { meta: { ...meta, flags: on ? 4 : 0 } } as Partial<Layer>);
+
+  const setSpec = (patch: Partial<ArcSpec>) =>
+    ring && set(ring.id, { spec: { ...ring.spec, ...patch } } as Partial<Layer>);
 
   const setFmt = (digits: number, padZero: boolean) =>
     set(layer.id, { digits: digits & 0x1f, padZero } as Partial<Layer>);
@@ -137,13 +141,20 @@
         {ID_LABELS[meta.source]} needs {frameLabels.length} frames, this widget has {images.length}
       </p>
     {/if}
-    {#if ring}
-      <p class="hint-xs">
-        gauge {ring.spec.min}–{ring.spec.max}, sweep {ring.spec.start}° → {ring.spec.end}°,
-        {ring.spec.width}px stroke{ring.spec.radius ? `, radius ${ring.spec.radius}` : ""}
-      </p>
-    {/if}
   </div>
+{/if}
+{#if ring}
+  <!-- the gauge's own range: frac = (value - min) / (max - min). The sweep and the stroke are
+       geometry and live in that section. Its own panel child, so it keeps the panel's row gap
+       instead of sitting flush against the source select. -->
+  <div class="row">
+    <span class="field-label w-md">gauge</span>
+    <Input type="number" value={String(ring.spec.min)} onInput={(v) => setSpec({ min: num(v) })} />
+    <span class="field-label w-md">to</span>
+    <Input type="number" value={String(ring.spec.max)} onInput={(v) => setSpec({ max: num(v) })} />
+  </div>
+{/if}
+{#if meta}
   <div class="check-row">
     <Checkbox checked={isAccent(meta)} onChange={(v) => setAccent(v)} />
     <button type="button" class="check-label" onclick={() => setAccent(!isAccent(meta))}

--- a/src/lib/modules/editor/core/document/edits.ts
+++ b/src/lib/modules/editor/core/document/edits.ts
@@ -14,9 +14,34 @@ import {
   type GroupLayer,
   type Layer,
   type NodeId,
+  type RingLayer,
   type Screen,
 } from "./doc";
+import { FULL_BLEED_R } from "../render/arc";
 import { SLOT_SEL_ID, isSlotSel } from "./sources";
+
+/** What a ring with no bitmap is drawn at: its own radius, else the widget box, else the renderer's
+ *  last-resort guess — the same ladder as drawProceduralArc. */
+export const ringRadius = (l: RingLayer) =>
+  l.spec.radius || (l.meta.auto ? 0 : Math.round(l.meta.w / 2)) || 60;
+
+/** Resizing a ring is not resizing its pixels. `meta.w/h` is the circle drawSector pivots the
+ *  filled sector around — NOT the bitmap, which may be cropped to the arc's bounding box — and a
+ *  ring with no bitmap has nothing but `spec.radius`. Both have to follow the layer or the sector
+ *  swings around the old centre and the ring tears. A circle takes one factor, so a non-uniform
+ *  drag is read as the axis that actually moved; `auto` is a group's "size me from my content"
+ *  sentinel rather than a diameter, so it is left alone. */
+export function scaleRing(l: RingLayer, kx: number, ky: number): Partial<RingLayer> {
+  const px = (v: number) => Math.max(1, Math.round(v));
+  const meta = (w: number, h: number) => (l.meta.auto ? {} : { meta: { ...l.meta, w, h } });
+
+  if (l.frames.length)
+    return l.meta.w && l.meta.h ? meta(px(l.meta.w * kx), px(l.meta.h * ky)) : {};
+  const k = Math.abs(kx - 1) >= Math.abs(ky - 1) ? kx : ky;
+  const r = Math.min(FULL_BLEED_R - 1, Math.max(2, Math.round(ringRadius(l) * k)));
+
+  return { spec: { ...l.spec, radius: r, width: px(l.spec.width * k) }, ...meta(2 * r, 2 * r) };
+}
 
 export const childrenOf = (l: Layer): readonly Layer[] =>
   l.kind === "group" ? l.children : l.kind === "raw" ? (l.children ?? []) : [];

--- a/src/lib/modules/editor/core/render/arc.ts
+++ b/src/lib/modules/editor/core/render/arc.ts
@@ -77,6 +77,11 @@ export function progressFrac(id: number, sim: Sim, t: TimeParts, spec: ArcSpec):
   return Math.max(0, Math.min(1, (v - spec.min) / (spec.max - spec.min || 1)));
 }
 
+/** A ring this big is drawn from the screen centre, ignoring its own x/y — a dial-sized ring in the
+ *  corpus sits at 0,0 or 3,3, and only the centre reading makes those land concentric. Editing has
+ *  to stay below it (see scaleRing), or a resize would silently throw the position away. */
+export const FULL_BLEED_R = 230;
+
 // ponytail: image-backed arcs (0x5b) start at 12 o'clock, not the 3-o'clock/LVGL convention
 // documented for procedural arcs (0x5a) — measured against Function's battery ring (id 0x24):
 // our gap centered ~90° clockwise of the baked preview's at start=0. Confirmed again on Combo's
@@ -138,8 +143,8 @@ export function drawProceduralArc(
   // radius: meta.w/h (the widget's own diameter) when known, spec.radius (0x5a only)
   // as an override, 60 as a last-resort guess for older/short structs with w=0
   const r = spec.radius || (w ? Math.round(w / 2) : 60);
-  const cx = r >= 230 ? CENTER : x + r,
-    cy = r >= 230 ? CENTER : y + r;
+  const cx = r >= FULL_BLEED_R ? CENTER : x + r,
+    cy = r >= FULL_BLEED_R ? CENTER : y + r;
   const a0 = radians(spec.start);
   const sweep = sweepOf(spec);
   // no explicit meta color (byte 7 !== 1, e.g. the plain steps ring) — falls back to a

--- a/src/lib/modules/editor/core/render/render.ts
+++ b/src/lib/modules/editor/core/render/render.ts
@@ -30,7 +30,7 @@ import {
   type Point,
   type Size,
 } from "./canvas";
-import { drawProceduralArc, drawSector, hexRGB, progressFrac } from "./arc";
+import { FULL_BLEED_R, drawProceduralArc, drawSector, hexRGB, progressFrac } from "./arc";
 import { CENTER, SCREEN } from "./screen";
 
 /** One layer drawn at a scale it doesn't have yet — what a corner drag shows while it lasts.
@@ -245,8 +245,8 @@ function drawRing(
       ringColorOf(l.meta) ?? hexRGB(env.sim.accentColor),
     );
     const r = size.w / 2;
-    const cx = r >= 230 ? CENTER : x + r,
-      cy = r >= 230 ? CENTER : y + r;
+    const cx = r >= FULL_BLEED_R ? CENTER : x + r,
+      cy = r >= FULL_BLEED_R ? CENTER : y + r;
 
     if (env.ctx) env.hits?.push({ layer: l, x: cx - r, y: cy - r, w: size.w, h: size.h });
     return size;

--- a/src/lib/modules/editor/model/assets.model.ts
+++ b/src/lib/modules/editor/model/assets.model.ts
@@ -271,6 +271,15 @@ const resizeImageFx = attach({
 
       patch = { pivotX, pivotY, x: cx - pivotX, y: cy - pivotY };
     }
+    // A ring's meta.w/h is the circle its filled sector pivots around, NOT the bitmap (which may
+    // be cropped to the arc's bounding box) — scaled by the same factors, or the sector swings
+    // around the old centre and the ring tears as soon as it is resized. `auto` is the group's
+    // "size me from my content" sentinel, not a diameter.
+    if (l.kind === "ring" && l.meta.w && l.meta.h && !l.meta.auto)
+      patch = {
+        ...patch,
+        meta: { ...l.meta, w: dim(l.meta.w * sx), h: dim(l.meta.h * sy) },
+      } as Partial<Layer>;
     return { assets, cache: cached, layer: l.id, patch };
   },
 });

--- a/src/lib/modules/editor/model/assets.model.ts
+++ b/src/lib/modules/editor/model/assets.model.ts
@@ -23,7 +23,7 @@ import {
   type ImageCache,
   type ImageId,
 } from "../core/document/doc";
-import { findLayer, patchLayer } from "../core/document/edits";
+import { findLayer, patchLayer, scaleRing } from "../core/document/edits";
 import type { Layer, NodeId } from "../core/document/doc";
 import type { Resource } from "../core/format";
 import { $doc, committed, docLoaded } from "./doc.model";
@@ -271,15 +271,10 @@ const resizeImageFx = attach({
 
       patch = { pivotX, pivotY, x: cx - pivotX, y: cy - pivotY };
     }
-    // A ring's meta.w/h is the circle its filled sector pivots around, NOT the bitmap (which may
-    // be cropped to the arc's bounding box) — scaled by the same factors, or the sector swings
-    // around the old centre and the ring tears as soon as it is resized. `auto` is the group's
-    // "size me from my content" sentinel, not a diameter.
-    if (l.kind === "ring" && l.meta.w && l.meta.h && !l.meta.auto)
-      patch = {
-        ...patch,
-        meta: { ...l.meta, w: dim(l.meta.w * sx), h: dim(l.meta.h * sy) },
-      } as Partial<Layer>;
+    // A ring's own circle (see scaleRing) follows its art. Measured against the asset's CURRENT
+    // size, not sx/sy: those are relative to the PINNED ORIGINAL, so multiplying an already-scaled
+    // meta by them compounds — halving a 284px ring twice would land its circle on 36, not 71.
+    if (l.kind === "ring") patch = { ...patch, ...scaleRing(l, tw / first.w, th / first.h) };
     return { assets, cache: cached, layer: l.id, patch };
   },
 });
@@ -331,6 +326,9 @@ const resizeGroupFx = attach({
         : null;
       const moved = { ...l, x: scale(l.x), y: scaleY(l.y) } as Layer;
 
+      // a ring's circle isn't its pixels, and a ring with no pixels at all still has a size —
+      // both are the group's factors, same rule as the standalone resize above
+      if (moved.kind === "ring") return { ...moved, ...scaleRing(moved, kw, kh) };
       if (moved.kind !== "hand" || !scaled) return moved;
       // the pivot is a coordinate inside the art, so it scales with it
       return {

--- a/src/lib/modules/editor/model/edit.model.ts
+++ b/src/lib/modules/editor/model/edit.model.ts
@@ -120,6 +120,18 @@ export const slotBindSet = createEvent<{ id: NodeId; slot: number | null; metric
  *  edit. See SLOT_METRIC_CHOICES for what the corpus uses. */
 export const slotMetricAdded = createEvent<{ id: NodeId; metric: number }>();
 export const slotMetricRemoved = createEvent<{ id: NodeId; metric: number }>();
+/** Give a procedural ring (0x5a, no art) a bitmap: from there it draws clipped to the filled
+ *  sector, like every 0x5b ring — the corpus has 0x5a rings with an image, so the spec tag
+ *  doesn't have to change. Replacing that art afterwards is the usual frame thumbnail. */
+export const ringImageAdded = createEvent<{ id: NodeId; file: File }>();
+/** A corner drag / arrow-key resize on a ring with no art: there are no pixels to rescale, the
+ *  size IS the 0x5a spec. Factors rather than a size, like a group — see resizeRingFactor. */
+export const ringResized = createEvent<{
+  layer: NodeId;
+  kw: number;
+  kh: number;
+  at?: { x: number; y: number };
+}>();
 export const frameMoved = createEvent<{ id: NodeId; from: number; to: number }>();
 export const alignRequested = createEvent<AlignDir>();
 /** meta.source — the data a widget reads. Not a plain patch: value-indexed sources also fix the
@@ -312,6 +324,29 @@ const addSlotMetricFx = attach({
         [frame, { id: frame, cf: r.cf, w: r.w, h: r.h, data: r.data }],
       ]),
       cache: new Map<ImageId, ImageCache>([[frame, { bitmap: r.bitmap }]]),
+    };
+  },
+});
+
+// The first bitmap a procedural ring gets. meta.w/h follow the art, because that is the circle
+// drawSector pivots the filled sector around — a ring whose meta says a different diameter draws
+// its sector off-centre.
+const addRingImageFx = attach({
+  source: $doc,
+  async effect(doc, { id, file }: { id: NodeId; file: File }) {
+    const l = doc ? findLayer(doc, id) : null;
+
+    if (!doc || l?.kind !== "ring" || l.locked || l.frames.length) return null;
+    const r = await resourceFromFile(file, 5);
+    const image = newImageId();
+
+    return {
+      id,
+      image,
+      assets: new Map<ImageId, ImageAsset>([
+        [image, { id: image, cf: r.cf, w: r.w, h: r.h, data: r.data }],
+      ]),
+      cache: new Map<ImageId, ImageCache>([[image, { bitmap: r.bitmap }]]),
     };
   },
 });
@@ -549,6 +584,58 @@ sample({
   fn: ({ cache }) => cache,
   target: cachePatched,
 });
+sample({
+  clock: ringImageAdded,
+  target: addRingImageFx,
+});
+sample({
+  clock: addRingImageFx.doneData,
+  filter: Boolean,
+  fn: ({ id, image, assets }) => ({
+    edit: (doc: Doc) => {
+      const l = findLayer(doc, id);
+      const a = assets.get(image)!;
+
+      if (l?.kind !== "ring") return doc;
+      return patchLayer(withAssets(doc, assets), id, {
+        frames: [image],
+        meta: { ...l.meta, w: a.w, h: a.h },
+      } as Partial<Layer>);
+    },
+  }),
+  target: committed,
+});
+sample({
+  clock: addRingImageFx.doneData,
+  filter: Boolean,
+  fn: ({ cache }) => cache,
+  target: cachePatched,
+});
+
+// A ring with no art has no pixels to rescale: its size is spec.radius (and meta.w/h, which the
+// renderer falls back to), and the stroke scales with it so the drag lands where the preview —
+// a plain ctx.scale — showed it. A circle takes one factor; a corner drag hands over two.
+sample({
+  clock: ringResized,
+  fn: ({ layer, kw, kh, at }) => ({
+    edit: (doc: Doc) => {
+      const l = findLayer(doc, layer);
+
+      if (l?.kind !== "ring" || l.locked || l.frames.length) return doc;
+      const k = Math.max(kw, kh);
+      const r = Math.max(2, Math.round((l.spec.radius || Math.round(l.meta.w / 2) || 60) * k));
+
+      return patchLayer(doc, layer, {
+        spec: { ...l.spec, radius: r, width: Math.max(1, Math.round(l.spec.width * k)) },
+        meta: { ...l.meta, w: 2 * r, h: 2 * r },
+        ...at,
+      } as Partial<Layer>);
+    },
+    coalesce: 600, // a live drag is one history entry, same as an image resize
+  }),
+  target: committed,
+});
+
 sample({
   clock: slotMetricRemoved,
   source: $doc,

--- a/src/lib/modules/editor/model/edit.model.ts
+++ b/src/lib/modules/editor/model/edit.model.ts
@@ -19,6 +19,7 @@ import {
   patchLayer,
   removeLayer,
   repointFrames,
+  scaleRing,
   setSlotBinding,
   shiftLayer,
   siblingsOf,
@@ -124,8 +125,8 @@ export const slotMetricRemoved = createEvent<{ id: NodeId; metric: number }>();
  *  sector, like every 0x5b ring — the corpus has 0x5a rings with an image, so the spec tag
  *  doesn't have to change. Replacing that art afterwards is the usual frame thumbnail. */
 export const ringImageAdded = createEvent<{ id: NodeId; file: File }>();
-/** A corner drag / arrow-key resize on a ring with no art: there are no pixels to rescale, the
- *  size IS the 0x5a spec. Factors rather than a size, like a group — see resizeRingFactor. */
+/** A corner drag, arrow key or size field on a ring with no art: there are no pixels to rescale,
+ *  the size IS the 0x5a spec. Factors rather than a size, like a group — see scaleRing. */
 export const ringResized = createEvent<{
   layer: NodeId;
   kw: number;
@@ -597,9 +598,12 @@ sample({
       const a = assets.get(image)!;
 
       if (l?.kind !== "ring") return doc;
+      // the art IS the ring's circle now: meta and the spec's own radius both take it, or the .bin
+      // would carry a diameter the widget no longer has. `auto` keeps its 0x8000 sentinel.
       return patchLayer(withAssets(doc, assets), id, {
         frames: [image],
-        meta: { ...l.meta, w: a.w, h: a.h },
+        spec: { ...l.spec, radius: Math.round(a.w / 2) },
+        ...(l.meta.auto ? {} : { meta: { ...l.meta, w: a.w, h: a.h } }),
       } as Partial<Layer>);
     },
   }),
@@ -622,14 +626,12 @@ sample({
       const l = findLayer(doc, layer);
 
       if (l?.kind !== "ring" || l.locked || l.frames.length) return doc;
-      const k = Math.max(kw, kh);
-      const r = Math.max(2, Math.round((l.spec.radius || Math.round(l.meta.w / 2) || 60) * k));
+      const patch = scaleRing(l, kw, kh);
+      const spec = patch.spec!;
 
-      return patchLayer(doc, layer, {
-        spec: { ...l.spec, radius: r, width: Math.max(1, Math.round(l.spec.width * k)) },
-        meta: { ...l.meta, w: 2 * r, h: 2 * r },
-        ...at,
-      } as Partial<Layer>);
+      // a factor that rounds to the same ring is not an edit — it must not eat an undo
+      if (!at && spec.radius === l.spec.radius && spec.width === l.spec.width) return doc;
+      return patchLayer(doc, layer, { ...patch, ...at } as Partial<Layer>);
     },
     coalesce: 600, // a live drag is one history entry, same as an image resize
   }),
@@ -1065,6 +1067,7 @@ sample({
     glyphsFx.failData,
     addSlotFx.failData,
     addSlotMetricFx.failData,
+    addRingImageFx.failData,
     addAodFx.failData,
     sourceIdFx.failData,
     alignFx.failData,

--- a/src/lib/modules/editor/pages/editor.svelte
+++ b/src/lib/modules/editor/pages/editor.svelte
@@ -66,6 +66,7 @@
     orderMoved,
     resizeImageRequested,
     resizeGroupRequested,
+    ringResized,
     $lockAspect: lockAspect,
     loadRequested,
     newFaceRequested,
@@ -386,8 +387,11 @@
   /** Does anything under this layer have pixels to scale? A group has none of its own. */
   const hasArt = (l: Layer): boolean =>
     framesOf(l).length > 0 || (l.kind === "group" && l.children.some(hasArt));
+  /** A ring with no art still resizes — its size is the 0x5a spec, not pixels (see ringResized). */
+  const isBareRing = (l: Layer): boolean => l.kind === "ring" && !l.frames.length;
   // locked is editor-only (see doc.ts): the layer still draws, it just stops answering the canvas
-  const resizable = (l: Layer | null): boolean => Boolean(l) && hasArt(l!) && !l!.locked;
+  const resizable = (l: Layer | null): boolean =>
+    Boolean(l) && (hasArt(l!) || isBareRing(l!)) && !l!.locked;
 
   type Rz = {
     layer: Layer;
@@ -438,6 +442,10 @@
     // a group has no pixels of its own: resizing it scales everything under it, by factor
     if (z.layer.kind === "group") {
       resizeGroupRequested({ layer: z.layer.id, kw, kh, at });
+      return;
+    }
+    if (isBareRing(z.layer)) {
+      ringResized({ layer: z.layer.id, kw, kh, at });
       return;
     }
     resizeImageRequested({
@@ -684,6 +692,10 @@
 
     if (l.kind === "group") {
       resizeGroupRequested({ layer: l.id, kw, kh });
+      return;
+    }
+    if (isBareRing(l)) {
+      ringResized({ layer: l.id, kw, kh });
       return;
     }
     const r0 = firstAsset(l);

--- a/src/lib/modules/editor/pages/editor.svelte
+++ b/src/lib/modules/editor/pages/editor.svelte
@@ -611,7 +611,9 @@
       // wide layer pulling the short side barely moved it. Shift inverts the lock, as usual.
       const rx = Math.abs(p.x - rz.ax) / rz.dx0,
         ry = Math.abs(p.y - rz.ay) / rz.dy0;
-      const locked = $lockAspect !== e.shiftKey;
+      // a ring is a circle: scaling it per axis would show a preview the model can't reproduce,
+      // and `at` below anchors the corner for whatever factors the preview used
+      const locked = isBareRing(rz.layer) || $lockAspect !== e.shiftKey;
       const [sw, sh] = locked ? [Math.max(rx, ry), Math.max(rx, ry)] : [rx, ry];
 
       rz.gw = Math.max(1, Math.round(rz.w0 * sw));

--- a/tests/editor-ring.browser.test.ts
+++ b/tests/editor-ring.browser.test.ts
@@ -4,6 +4,7 @@
 import { test, expect, vi } from "vitest";
 import { findLayer } from "$lib/modules/editor/core/document/edits";
 import type { Layer, NodeId, RingLayer } from "$lib/modules/editor/core/document/doc";
+import { FULL_BLEED_R } from "$lib/modules/editor/core/render/arc";
 import { editorModel } from "$lib/modules/editor/model";
 import url from "./__fixtures__/Default__276__Dichotomy.bin?url";
 
@@ -85,6 +86,78 @@ test("resizing a ring's art scales meta.w/h with it — the sector pivot is that
   await vi.waitFor(() => expect(ringById(ring.id).meta.w).not.toBe(w0));
 
   expect(ringById(ring.id).meta.w).toBe(Math.round(w0 / 2));
+});
+
+// The factors rescaleFrames reports are relative to the PINNED ORIGINAL bitmap, so a second resize
+// that multiplies the already-scaled meta by them lands on a quarter instead of a half.
+test("halving a ring's art twice halves its circle twice, not compounds", async () => {
+  await load();
+  const ring = imageRing();
+  const asset0 = doc().images.get(ring.frames[0])!;
+  const w0 = ring.meta.w;
+  const half = (n: number) => {
+    editorModel.resizeImageRequested({
+      layer: ring.id,
+      w: Math.round(asset0.w / n),
+      h: Math.round(asset0.h / n),
+    });
+  };
+
+  half(2);
+  await vi.waitFor(() => expect(ringById(ring.id).meta.w).toBe(Math.round(w0 / 2)));
+  half(4);
+  await vi.waitFor(() =>
+    expect(doc().images.get(ring.frames[0])!.w).toBe(Math.round(asset0.w / 4)),
+  );
+
+  expect(ringById(ring.id).meta.w).toBe(Math.round(w0 / 4));
+});
+
+// A circle takes one factor: the axis that actually moved. Reading it as max() froze every
+// shrink (max(0.9, 1) === 1), which is what an arrow-key resize hands over.
+test("a one-axis shrink shrinks a bare ring, and a no-op resize keeps the undo stack", async () => {
+  await load();
+  editorModel.nodeAdded("ring");
+  const id = editorModel.$sel.getState()!;
+  const r0 = ringById(id).spec.radius;
+
+  editorModel.ringResized({ layer: id, kw: 0.5, kh: 1 });
+  expect(ringById(id).spec.radius).toBe(Math.round(r0 / 2));
+
+  const undos = editorModel.$undoN.getState();
+
+  editorModel.ringResized({ layer: id, kw: 1, kh: 1 });
+  expect(editorModel.$undoN.getState()).toBe(undos);
+});
+
+// drawProceduralArc draws a ring this big from the screen centre and ignores its x/y, so a drag
+// that crossed the line would teleport the ring and throw its position away.
+test("a bare ring can't be resized past the full-bleed radius", async () => {
+  await load();
+  editorModel.nodeAdded("ring");
+  const id = editorModel.$sel.getState()!;
+
+  editorModel.ringResized({ layer: id, kw: 8, kh: 8 });
+
+  expect(ringById(id).spec.radius).toBe(FULL_BLEED_R - 1);
+});
+
+// Same rule one level up: a group drag rescales its children's pixels, and a ring's circle is not
+// its pixels — a bare ring inside a group has none at all.
+test("resizing a group scales a ring child's circle too", async () => {
+  await load();
+  editorModel.nodeAdded("ring");
+  const id = editorModel.$sel.getState()!;
+  const r0 = ringById(id).spec.radius;
+
+  editorModel.select(id);
+  editorModel.groupRequested();
+  const group = editorModel.$sel.getState()!;
+
+  editorModel.resizeGroupRequested({ layer: group, kw: 0.5, kh: 0.5 });
+  await vi.waitFor(() => expect(ringById(id).spec.radius).toBe(Math.round(r0 / 2)));
+
+  expect(ringById(id).meta.w).toBe(2 * Math.round(r0 / 2));
 });
 
 test("a ring with no art can be given one, and keeps the bitmap's circle", async () => {

--- a/tests/editor-ring.browser.test.ts
+++ b/tests/editor-ring.browser.test.ts
@@ -1,0 +1,103 @@
+// Progress rings are the one widget that draws without any art (the stroked 0x5a fallback), so
+// they resize through their spec rather than through their pixels — and the ones that DO have art
+// carry a second size, meta.w/h, which is the circle the filled sector pivots around.
+import { test, expect, vi } from "vitest";
+import { findLayer } from "$lib/modules/editor/core/document/edits";
+import type { Layer, NodeId, RingLayer } from "$lib/modules/editor/core/document/doc";
+import { editorModel } from "$lib/modules/editor/model";
+import url from "./__fixtures__/Default__276__Dichotomy.bin?url";
+
+const doc = () => editorModel.$doc.getState()!;
+const ringById = (id: NodeId) => findLayer(doc(), id) as RingLayer;
+
+async function load() {
+  const buf = await fetch(url).then((r) => r.arrayBuffer());
+
+  await new Promise<void>((resolve) => {
+    const unwatch = editorModel.loadDone.watch(() => {
+      unwatch();
+      resolve();
+    });
+
+    editorModel.loadRequested({ buf, label: "ring-test" });
+  });
+}
+
+/** A tiny opaque PNG, as a File — what the "use a ring bitmap" picker hands over. */
+async function png(size: number): Promise<File> {
+  const c = document.createElement("canvas");
+
+  c.width = c.height = size;
+  const ctx = c.getContext("2d")!;
+
+  ctx.fillStyle = "#fff";
+  ctx.fillRect(0, 0, size, size);
+  const blob = await new Promise<Blob>((r) => c.toBlob((b) => r(b!), "image/png"));
+
+  return new File([blob], "ring.png", { type: "image/png" });
+}
+
+/** The first ring in the fixture that has art — Dichotomy's are 0x5b half-rings. */
+const imageRing = () => {
+  const out: RingLayer[] = [];
+  const walk = (ls: readonly Layer[]) => {
+    for (const l of ls) {
+      if (l.kind === "ring" && l.frames.length) out.push(l);
+      if (l.kind === "group") walk(l.children);
+    }
+  };
+
+  doc().screens.forEach((s) => walk(s.layers));
+  return out[0];
+};
+
+test("a ring with no art resizes through its spec, not its pixels", async () => {
+  await load();
+  editorModel.nodeAdded("ring");
+  const id = editorModel.$sel.getState()!;
+  const before = ringById(id);
+
+  expect(before.frames.length).toBe(0);
+  editorModel.ringResized({ layer: id, kw: 2, kh: 2 });
+  const after = ringById(id);
+
+  expect(after.spec.radius).toBe(before.spec.radius * 2);
+  expect(after.spec.width).toBe(before.spec.width * 2);
+  // meta.w/h is what the renderer falls back to when there's no explicit radius — it has to agree
+  expect(after.meta.w).toBe(after.spec.radius * 2);
+  expect(after.meta.h).toBe(after.spec.radius * 2);
+});
+
+test("resizing a ring's art scales meta.w/h with it — the sector pivot is that circle", async () => {
+  await load();
+  const ring = imageRing();
+
+  expect(ring).toBeTruthy();
+  const frame = ring.frames[0];
+  const asset0 = doc().images.get(frame)!;
+  const w0 = ring.meta.w;
+
+  editorModel.resizeImageRequested({
+    layer: ring.id,
+    w: Math.round(asset0.w / 2),
+    h: Math.round(asset0.h / 2),
+  });
+  await vi.waitFor(() => expect(ringById(ring.id).meta.w).not.toBe(w0));
+
+  expect(ringById(ring.id).meta.w).toBe(Math.round(w0 / 2));
+});
+
+test("a ring with no art can be given one, and keeps the bitmap's circle", async () => {
+  await load();
+  editorModel.nodeAdded("ring");
+  const id = editorModel.$sel.getState()!;
+
+  editorModel.ringImageAdded({ id, file: await png(64) });
+  await vi.waitFor(() => expect(ringById(id).frames.length).toBe(1));
+
+  const l = ringById(id);
+
+  expect(doc().images.get(l.frames[0])!.w).toBe(64);
+  expect(l.meta.w).toBe(64);
+  expect(l.meta.h).toBe(64);
+});


### PR DESCRIPTION
Closes the resize/replace half of #22, and answers the rounded-corner half with corpus evidence.

### What was broken

A ring the editor creates is procedural — `0x5a`, no frames — and every sizing path assumes pixels:

* `geometry.svelte` reads w/h off the first frame, so a bare ring showed no size fields at all;
* `hasArt()` gated the canvas corner handles, so it couldn't be dragged either;
* nothing offered it a bitmap, so "replace the image in the progress ring" had no image to replace;
* the arc spec (sweep, stroke, gauge range) was a read-only hint string.

Separately, a ring **with** art resized its bitmap but not `meta.w/h` — and that is the circle
`drawSector` pivots the filled sector around, so the arc tore the moment the ring was resized.

### What's here

* **Inspector** — `size` (bare rings: `spec.radius` + `meta.w/h`, growing around its own centre),
  `stroke`, `start`/`end`, and `gauge min–max` in the source section next to the metric it reads.
* **Gap** — `start`/`end` are what #22's second point asks for: `20 → 340` leaves a 40° notch at
  the top for an icon, and the fill still spans the whole sweep.
* **Canvas** — corner drags and arrow keys resize a bare ring through `ringResized`: one factor on
  radius and stroke together, so the drop lands where the preview's `ctx.scale` showed it.
* **Ring art** — `ringImageAdded` gives a bare ring a bitmap; the tag stays `0x5a` (the corpus has
  `0x5a` rings with an image), and `meta.w/h` take the bitmap's size.
* **Fix** — a ring's `meta.w/h` now scale with its art on resize.
* Aligned the geometry section's label column while I was in there: `x/y`, `w/h`, `align` and the
  pivot row sized to their text, so every row started its inputs somewhere different.

### Rounded caps — not possible, and I checked properly

100 corpus faces, 79 arc widgets. Every one is `0x80`/`0x81` with exactly two children (struct +
spec) — no style node exists. The spec is a fixed 19/17 bytes with everything decoded but a 3-byte
trailer, and that trailer disagrees between visually identical sibling rings in 8 faces. 17 rings
carry no bitmap (so firmware strokes them); the 4 with a partial sweep show both ends in their baked
preview, at three different trailer values — all flat radial caps. Details in
https://github.com/freethinkel/fmc/issues/22#issuecomment-5233668989.

### Verification

`pnpm check` 0 errors, `pnpm lint` clean, 164 tests pass including three new ones in
`tests/editor-ring.browser.test.ts` (spec-driven resize, `meta.w/h` following the art, giving a bare
ring a bitmap). Also driven by hand in a real browser: add ring → drag a corner (200 → 260, stroke
10 → 13) → gap at 20/340 → drop a ring PNG on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLHPEnYV5UMkne4WBTCk5s
