### PR TITLE
Let a progress ring's art be swapped for art of another size

### DIFF
--- a/src/lib/modules/editor/core/document/edits.ts
+++ b/src/lib/modules/editor/core/document/edits.ts
@@ -34,14 +34,27 @@ export const ringRadius = (l: RingLayer) =>
 export function scaleRing(l: RingLayer, kx: number, ky: number): Partial<RingLayer> {
   const px = (v: number) => Math.max(1, Math.round(v));
   const meta = (w: number, h: number) => (l.meta.auto ? {} : { meta: { ...l.meta, w, h } });
-
-  if (l.frames.length)
-    return l.meta.w && l.meta.h ? meta(px(l.meta.w * kx), px(l.meta.h * ky)) : {};
   const k = Math.abs(kx - 1) >= Math.abs(ky - 1) ? kx : ky;
+
+  if (l.frames.length) {
+    // 0x5b carries no radius at all, but a 0x5a ring WITH art writes one — it has to keep
+    // agreeing with the art, the same way it is set when the art first arrives
+    const spec = l.spec.radius ? { spec: { ...l.spec, radius: px(l.spec.radius * k) } } : {};
+
+    return { ...spec, ...(l.meta.w && l.meta.h ? meta(px(l.meta.w * kx), px(l.meta.h * ky)) : {}) };
+  }
   const r = Math.min(FULL_BLEED_R - 1, Math.max(2, Math.round(ringRadius(l) * k)));
 
   return { spec: { ...l.spec, radius: r, width: px(l.spec.width * k) }, ...meta(2 * r, 2 * r) };
 }
+
+/** Swapping a ring's bitmap for one of a different size is a resize by another name — the circle
+ *  the sector pivots around lives in the layer, not in the art. Every ring drawing `image` follows
+ *  it by the same rule as a drag (scaleRing); an asset can be shared, so this is all of them. */
+export const fitRingsToArt = (doc: Doc, image: ImageId, kx: number, ky: number): Doc =>
+  mapLayers(doc, (l) =>
+    l.kind === "ring" && l.frames.includes(image) ? { ...l, ...scaleRing(l, kx, ky) } : l,
+  );
 
 export const childrenOf = (l: Layer): readonly Layer[] =>
   l.kind === "group" ? l.children : l.kind === "raw" ? (l.children ?? []) : [];

--- a/src/lib/modules/editor/model/assets.model.ts
+++ b/src/lib/modules/editor/model/assets.model.ts
@@ -23,7 +23,7 @@ import {
   type ImageCache,
   type ImageId,
 } from "../core/document/doc";
-import { findLayer, patchLayer, scaleRing } from "../core/document/edits";
+import { findLayer, fitRingsToArt, patchLayer, scaleRing } from "../core/document/edits";
 import type { Layer, NodeId } from "../core/document/doc";
 import type { Resource } from "../core/format";
 import { $doc, committed, docLoaded } from "./doc.model";
@@ -504,7 +504,16 @@ sample({
   clock: [replaceImageFx.doneData, clearImageFx.doneData],
   filter: Boolean,
   fn: ({ asset }) => ({
-    edit: (doc: Doc) => ({ ...doc, images: new Map(doc.images).set(asset.id, asset) }),
+    edit: (doc: Doc) => {
+      const old = doc.images.get(asset.id);
+      const next = { ...doc, images: new Map(doc.images).set(asset.id, asset) };
+
+      // a ring's circle isn't its pixels (see scaleRing), so art of a different size moves it —
+      // otherwise the sector keeps pivoting around the circle the old bitmap had
+      return old && old.w && old.h && (old.w !== asset.w || old.h !== asset.h)
+        ? fitRingsToArt(next, asset.id, asset.w / old.w, asset.h / old.h)
+        : next;
+    },
   }),
   target: committed,
 });

--- a/tests/editor-ring.browser.test.ts
+++ b/tests/editor-ring.browser.test.ts
@@ -173,4 +173,29 @@ test("a ring with no art can be given one, and keeps the bitmap's circle", async
   expect(doc().images.get(l.frames[0])!.w).toBe(64);
   expect(l.meta.w).toBe(64);
   expect(l.meta.h).toBe(64);
+
+  // and swapping that art for a bigger bitmap moves the circle again — an editor-made ring is
+  // 0x5a, so its spec radius is written to the file and has to follow too
+  editorModel.replaceImageRequested({ id: l.frames[0], file: await png(128) });
+  await vi.waitFor(() => expect(ringById(id).meta.w).toBe(128));
+
+  expect(ringById(id).spec.radius).toBe(64);
+});
+
+// Swapping the bitmap is a resize by another name: the circle the sector pivots around is
+// meta.w/h, not the art, so art of a different size has to move it — or the replaced ring keeps
+// swinging around the old centre, which is what "can't replace the image" looks like on screen.
+test("replacing a ring's art moves its circle with it", async () => {
+  await load();
+  const ring = imageRing();
+  const frame = ring.frames[0];
+  const asset0 = doc().images.get(frame)!;
+  const w0 = ring.meta.w,
+    h0 = ring.meta.h;
+
+  editorModel.replaceImageRequested({ id: frame, file: await png(64) });
+  await vi.waitFor(() => expect(doc().images.get(frame)!.w).toBe(64));
+
+  expect(ringById(ring.id).meta.w).toBe(Math.round((w0 * 64) / asset0.w));
+  expect(ringById(ring.id).meta.h).toBe(Math.round((h0 * 64) / asset0.h));
 });


### PR DESCRIPTION
Closes #22.

**Resize** — already fixed on `main` by "Give a ring one sizing rule, and stop the resize paths disagreeing". Verified rather than re-done: `scaleRing` is the single sizing rule, and the inspector's size field, corner drags, arrow keys and a group resize all go through it. A ring with no art resizes through its arc spec; one with art rescales its pixels and moves its own circle with them.

**Replacing the art** — this PR. `replaceImageFx` wrote the new asset and nothing else, so a ring kept the circle its old bitmap had. That circle is `meta.w/h`, which is what `drawSector` pivots the filled sector around: swap a 284px ring for a 64px one and the sector still swings around a 284px centre, with the art anchored to the side of a circle it no longer fills. On screen that reads as "the image can't be replaced".

A swap is a resize by another name, so it now goes through the same rule — `fitRingsToArt` scales every ring drawing the asset (assets are shared) by the factor the new pixels bring. `scaleRing` also carries `spec.radius` through the with-art case now: 0x5b never writes a radius, but an editor-made 0x5a ring does, so replacing or resizing its art exported a diameter the widget no longer had — the same defect `addRingImageFx` already fixes on the way in.

Two regression tests, both checked to fail against the old code. Full suite: 193 passing; `check`, `lint` and `format:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgJ39ZDcxiHJt3uabAgSL8