### PR TITLE
Read the watch's sunrise, sunset, SpO2 and sleep sources

### DIFF
--- a/docs/cmf-protocol.md
+++ b/docs/cmf-protocol.md
@@ -81,11 +81,20 @@ placeholder bytes (`(1,0,0)`/`(4,0,0)`), not a meaningful color, at least on fla
 | 0x15/0x16         | month (1-12)                    | 0x49,0x6a,   | steps & calories,         |
 | 0x17              | day of month                    | 0x6c,0x6f    | exact metric unconfirmed  |
 | 0x18              | weekday (0=Sunday)              | 0x79+slotIdx | synthetic: slot selection |
+| 0x84/0x85         | sunrise hour/minute             | 0x86/0x87    | sunset hour/minute        |
 
 Reconciled with §16 of the protocol repo (joshuapassos/CMF-Watch-Pro-2-BLE-Protocol), whose
 hand-angle/tens-units ids come from disassembling the firmware getter table; the health labels
 are ours, calibrated against the companion app's slot-menu icons. Unlisted: `0x82`, which drives
 Activity_Mood's fan gauge and is documented nowhere — treated as a goal percentage.
+
+`0x84..0x87` come from the one corpus face that binds them, `Default__280__Multifunction`: two
+auto-layout groups flanking its sun arc (`x=41` and `x=377`, both at `y=130`), each built like the
+face's own clock group — hour, separator image, minute widget declaring `max=60` — and rendering
+the `05:41` / `06:24` its screenshot shows. The hour appears to follow the device's 12/24h setting
+(that `06:24` is an evening sunset), which is how `idValue` drives it. The same face also reads
+`0x1b` (SpO2, next to heart rate) and `0x42`/`0x43` + a `0x46` ring (sleep hours/minutes) — read
+off its screenshot the same way, but not wired up.
 
 Any id can drive a `number` widget, an `image`-pick widget, or an arc ring — the mechanism
 is generic (see below), not hardcoded per id.

--- a/docs/cmf-protocol.md
+++ b/docs/cmf-protocol.md
@@ -82,6 +82,7 @@ placeholder bytes (`(1,0,0)`/`(4,0,0)`), not a meaningful color, at least on fla
 | 0x17              | day of month                    | 0x6c,0x6f    | exact metric unconfirmed  |
 | 0x18              | weekday (0=Sunday)              | 0x79+slotIdx | synthetic: slot selection |
 | 0x84/0x85         | sunrise hour/minute             | 0x86/0x87    | sunset hour/minute        |
+| 0x42/0x43/0x46    | sleep hours/minutes, ring       | 0x1b         | blood oxygen (SpO2)       |
 
 Reconciled with §16 of the protocol repo (joshuapassos/CMF-Watch-Pro-2-BLE-Protocol), whose
 hand-angle/tens-units ids come from disassembling the firmware getter table; the health labels
@@ -92,9 +93,12 @@ Activity_Mood's fan gauge and is documented nowhere — treated as a goal percen
 auto-layout groups flanking its sun arc (`x=41` and `x=377`, both at `y=130`), each built like the
 face's own clock group — hour, separator image, minute widget declaring `max=60` — and rendering
 the `05:41` / `06:24` its screenshot shows. The hour appears to follow the device's 12/24h setting
-(that `06:24` is an evening sunset), which is how `idValue` drives it. The same face also reads
-`0x1b` (SpO2, next to heart rate) and `0x42`/`0x43` + a `0x46` ring (sleep hours/minutes) — read
-off its screenshot the same way, but not wired up.
+(that `06:24` is an evening sunset), which is how `idValue` drives it.
+
+`0x1b` (SpO2 — the widget beside the heart rate, reading 98) and `0x42`/`0x43` plus the `0x46`
+ring (sleep hours/minutes, `7.36H` against the wearer's sleep goal) come off the same face and
+the same screenshot. The ring gauges the duration whole and divides by the goal, like a steps
+ring, so the simulator feeds it minutes and `goalOf` answers with the goal in minutes too.
 
 Any id can drive a `number` widget, an `image`-pick widget, or an arc ring — the mechanism
 is generic (see below), not hardcoded per id.

--- a/src/lib/modules/editor/components/SimPanel.svelte
+++ b/src/lib/modules/editor/components/SimPanel.svelte
@@ -7,7 +7,9 @@
     ID_METRIC,
     METRIC_GOAL,
     pickerLabel,
+    SLEEP_IDS,
     SUN_IDS,
+    type Sim,
     type SimMetric,
   } from "../core/document/sources";
   import { editorModel } from "../model";
@@ -25,7 +27,18 @@
     ["distance", "Distance, m", ""],
     ["temp", "Temperature, °", ""],
     ["aqi", "AQI", ""],
+    ["spo2", "Blood oxygen, %", ""],
     ["stands", "Stand hours", "Stand goal, hours"],
+  ];
+
+  // The clock-shaped fields: each feeds an hour source and a minute source (and, for sleep, a
+  // ring against its goal), so one time field beats the four number boxes those ids would ask
+  // for. Shown only while the document reads the ids behind them.
+  const TIMES: [keyof Sim & ("sunrise" | "sunset" | "sleep" | "sleepGoal"), string, number[]][] = [
+    ["sunrise", "Sunrise", SUN_IDS],
+    ["sunset", "Sunset", SUN_IDS],
+    ["sleep", "Sleep", SLEEP_IDS],
+    ["sleepGoal", "Sleep goal", SLEEP_IDS],
   ];
 
   const used = $derived(new Set($ids.map(({ id }) => ID_METRIC[id]).filter(Boolean)));
@@ -38,9 +51,9 @@
     return new Date(t - new Date().getTimezoneOffset() * 60000).toISOString().slice(0, 19);
   }
 
-  // Sunrise/sunset are one time each, feeding an hour and a minute source — so they get a time
-  // field rather than the two number boxes four ids would otherwise ask for.
-  const sunUsed = $derived($ids.some(({ id }) => SUN_IDS.includes(id)));
+  const shownTimes = $derived(
+    TIMES.filter(([, , behind]) => $ids.some(({ id }) => behind.includes(id))),
+  );
   const hhmm = (mins: number) =>
     `${String(Math.floor(mins / 60)).padStart(2, "0")}:${String(mins % 60).padStart(2, "0")}`;
   const minutes = (v: string) => {
@@ -138,24 +151,18 @@
       {/each}
     </div>
   {/if}
-  {#if sunUsed}
+  {#if shownTimes.length}
     <div class="fields-grid">
-      <div>
-        <span class="muted-label">Sunrise</span>
-        <Input
-          type="time"
-          value={hhmm($sim.sunrise)}
-          onInput={(v) => v && simPatched({ sunrise: minutes(v) })}
-        />
-      </div>
-      <div>
-        <span class="muted-label">Sunset</span>
-        <Input
-          type="time"
-          value={hhmm($sim.sunset)}
-          onInput={(v) => v && simPatched({ sunset: minutes(v) })}
-        />
-      </div>
+      {#each shownTimes as [key, label]}
+        <div>
+          <span class="muted-label">{label}</span>
+          <Input
+            type="time"
+            value={hhmm($sim[key])}
+            onInput={(v) => v && simPatched({ [key]: minutes(v) })}
+          />
+        </div>
+      {/each}
     </div>
   {/if}
 

--- a/src/lib/modules/editor/components/SimPanel.svelte
+++ b/src/lib/modules/editor/components/SimPanel.svelte
@@ -7,6 +7,7 @@
     ID_METRIC,
     METRIC_GOAL,
     pickerLabel,
+    SUN_IDS,
     type SimMetric,
   } from "../core/document/sources";
   import { editorModel } from "../model";
@@ -36,6 +37,17 @@
   function localISO(t: number) {
     return new Date(t - new Date().getTimezoneOffset() * 60000).toISOString().slice(0, 19);
   }
+
+  // Sunrise/sunset are one time each, feeding an hour and a minute source — so they get a time
+  // field rather than the two number boxes four ids would otherwise ask for.
+  const sunUsed = $derived($ids.some(({ id }) => SUN_IDS.includes(id)));
+  const hhmm = (mins: number) =>
+    `${String(Math.floor(mins / 60)).padStart(2, "0")}:${String(mins % 60).padStart(2, "0")}`;
+  const minutes = (v: string) => {
+    const [h, m] = v.split(":").map(Number);
+
+    return h * 60 + m;
+  };
 </script>
 
 <div class="panel">
@@ -124,6 +136,26 @@
           </div>
         {/if}
       {/each}
+    </div>
+  {/if}
+  {#if sunUsed}
+    <div class="fields-grid">
+      <div>
+        <span class="muted-label">Sunrise</span>
+        <Input
+          type="time"
+          value={hhmm($sim.sunrise)}
+          onInput={(v) => v && simPatched({ sunrise: minutes(v) })}
+        />
+      </div>
+      <div>
+        <span class="muted-label">Sunset</span>
+        <Input
+          type="time"
+          value={hhmm($sim.sunset)}
+          onInput={(v) => v && simPatched({ sunset: minutes(v) })}
+        />
+      </div>
     </div>
   {/if}
 

--- a/src/lib/modules/editor/core/document/sources.ts
+++ b/src/lib/modules/editor/core/document/sources.ts
@@ -71,8 +71,21 @@ export const ID_LABELS: Record<number, string> = {
   // Activity_Mood's fan gauge (0x80 ring, max 100). Undocumented anywhere — a goal percentage
   // by shape, metric unknown, so it reads steps like the other unlabelled slot ids.
   0x82: "goal % ?",
+  // Sunrise/sunset, read off the stock `Default__280__Multifunction` face — the only corpus file
+  // that binds them. Each is an hour/minute pair inside one auto-layout group flanking the sun
+  // arc (sunrise left at x=41, sunset right at x=377), laid out exactly like the face's own
+  // hour/minute clock group: hour first, separator image, then the minute, whose widget declares
+  // max=60. That, and the 05:41 / 06:24 the face renders on either side of the arc, is what
+  // names them.
+  0x84: "sunrise hour",
+  0x85: "sunrise min",
+  0x86: "sunset hour",
+  0x87: "sunset min",
   0x8b: "aqi",
 };
+
+/** The four sunrise/sunset sources, in the order a face lays them out. */
+export const SUN_IDS = [0x84, 0x85, 0x86, 0x87];
 
 // Value-indexed frame sets: the firmware picks images[value % count], so frame order is part
 // of the format. What each index MUST hold, for the sources where the value isn't the frame's
@@ -122,6 +135,12 @@ export interface Sim {
   stepsGoal: SimValue;
   calGoal: SimValue;
   standsGoal: SimValue; // ring denominator for 0x48, the watch's default stand goal is 12 h
+  // Minutes since midnight, feeding the 0x84..0x87 hour/minute pair each. ponytail: two numbers
+  // the user types, not a computed almanac — the watch gets these from the phone, and a preview
+  // has no location to compute them from. If one is ever wanted, sunrise/sunset from a lat/lon
+  // is a dozen lines of trigonometry that would replace exactly these two fields.
+  sunrise: number;
+  sunset: number;
   overrides: Record<number, number | string>;
   // preview override for accent-flagged widgets (see metaInfo's `accent` field / "Accent
   // color" in docs/cmf-protocol.md); null = draw the baked default. Applied async in
@@ -176,6 +195,8 @@ export function defaultSim(): Sim {
     stepsGoal: 10000,
     calGoal: 500,
     standsGoal: 12,
+    sunrise: 5 * 60 + 41, // the times the stock Multifunction face's own screenshot shows
+    sunset: 18 * 60 + 24,
     overrides: {}, // id -> number, manual override of any source
     accentColor: null,
     showSlotPlaceholders: false,
@@ -317,6 +338,17 @@ export function idValue(id: number, sim: Sim, t: TimeParts): number {
     // ponytail: slot-menu labels only, unit unverified — km int / plain AQI, override per face
     case 0x76:
       return Math.floor(Number(sim.distance) / 1000);
+    // Sunrise/sunset. The hour follows the device's 12/24h setting the way 0x01 does — the stock
+    // face's screenshot prints an evening sunset as "06:24" — so the sim's own 24-hour switch
+    // drives it; flip it, or override the id, if a device ever says otherwise.
+    case 0x84:
+      return sim.is24h ? Math.floor(sim.sunrise / 60) : h12(Math.floor(sim.sunrise / 60));
+    case 0x85:
+      return sim.sunrise % 60;
+    case 0x86:
+      return sim.is24h ? Math.floor(sim.sunset / 60) : h12(Math.floor(sim.sunset / 60));
+    case 0x87:
+      return sim.sunset % 60;
     default: {
       // every source that just hands its metric back, from the one table the panel groups by
       const metric = ID_METRIC[id];

--- a/src/lib/modules/editor/core/document/sources.ts
+++ b/src/lib/modules/editor/core/document/sources.ts
@@ -39,6 +39,9 @@ export const ID_LABELS: Record<number, string> = {
   0x18: "weekday",
   0x19: "steps",
   0x1a: "heart rate",
+  // Same face again (see 0x84 below): the widget beside its heart rate, reading 98 under a
+  // blood-oxygen icon on the screenshot.
+  0x1b: "blood oxygen",
   0x1c: "calories",
   0x1e: "calories",
   0x22: "distance km int",
@@ -49,6 +52,11 @@ export const ID_LABELS: Record<number, string> = {
   0x27: "calories (slot)?",
   0x30: "battery",
   0x36: "temperature",
+  // Last night's sleep, on the same face: an hours/minutes pair reading "7.36" inside a ring
+  // that gauges the same value against the wearer's sleep goal (0x81 ring, spec max 100).
+  0x42: "sleep hours",
+  0x43: "sleep min",
+  0x46: "sleep (ring)",
   0x48: "stand hours",
   0x49: "steps (slot)",
   0x5f: "temperature",
@@ -86,6 +94,8 @@ export const ID_LABELS: Record<number, string> = {
 
 /** The four sunrise/sunset sources, in the order a face lays them out. */
 export const SUN_IDS = [0x84, 0x85, 0x86, 0x87];
+/** Sleep: the hours/minutes pair and the ring gauging the same duration. */
+export const SLEEP_IDS = [0x42, 0x43, 0x46];
 
 // Value-indexed frame sets: the firmware picks images[value % count], so frame order is part
 // of the format. What each index MUST hold, for the sources where the value isn't the frame's
@@ -131,6 +141,7 @@ export interface Sim {
   temp: SimValue;
   distance: SimValue;
   aqi: SimValue;
+  spo2: SimValue; // blood oxygen, % (0x1b)
   stands: SimValue; // hours stood (0x48) — see ID_LABELS/idValue note, corrected from "calories"
   stepsGoal: SimValue;
   calGoal: SimValue;
@@ -141,6 +152,10 @@ export interface Sim {
   // is a dozen lines of trigonometry that would replace exactly these two fields.
   sunrise: number;
   sunset: number;
+  // Last night's sleep and the goal its ring divides by, both in minutes — same hour/minute
+  // split, so the panel offers them the same way.
+  sleep: number;
+  sleepGoal: number;
   overrides: Record<number, number | string>;
   // preview override for accent-flagged widgets (see metaInfo's `accent` field / "Accent
   // color" in docs/cmf-protocol.md); null = draw the baked default. Applied async in
@@ -191,12 +206,15 @@ export function defaultSim(): Sim {
     distance: 4520,
     temp: 25,
     aqi: 42,
+    spo2: 98,
     stands: 5,
     stepsGoal: 10000,
     calGoal: 500,
     standsGoal: 12,
     sunrise: 5 * 60 + 41, // the times the stock Multifunction face's own screenshot shows
     sunset: 18 * 60 + 24,
+    sleep: 7 * 60 + 36, // ditto, against the watch's own 8-hour default goal
+    sleepGoal: 8 * 60,
     overrides: {}, // id -> number, manual override of any source
     accentColor: null,
     showSlotPlaceholders: false,
@@ -226,6 +244,7 @@ export type SimMetric =
   | "distance"
   | "temp"
   | "aqi"
+  | "spo2"
   | "stands";
 
 /** Which metric each data source reads. The firmware exposes one metric under a pile of ids —
@@ -244,6 +263,7 @@ export const ID_METRIC: Record<number, SimMetric> = {
   0x6f: "steps",
   0x82: "steps",
   0x1a: "hr",
+  0x1b: "spo2",
   // 0x48/0x24 corrected against Function's widget-slot menu icons (standing figure/lightning
   // bolt, not calories/steps) — 0x48 is stand hours, 0x24 is battery.
   0x24: "battery",
@@ -349,6 +369,14 @@ export function idValue(id: number, sim: Sim, t: TimeParts): number {
       return sim.is24h ? Math.floor(sim.sunset / 60) : h12(Math.floor(sim.sunset / 60));
     case 0x87:
       return sim.sunset % 60;
+    // Sleep: the pair splits the duration, the ring reads it whole and divides by the goal
+    // (see goalOf) — the same shape as a steps ring.
+    case 0x42:
+      return Math.floor(sim.sleep / 60);
+    case 0x43:
+      return sim.sleep % 60;
+    case 0x46:
+      return sim.sleep;
     default: {
       // every source that just hands its metric back, from the one table the panel groups by
       const metric = ID_METRIC[id];
@@ -373,6 +401,7 @@ export function goalOf(id: number, sim: Sim): SimValue | undefined {
     0x1e: sim.calGoal,
     0x27: sim.calGoal,
     0x48: sim.standsGoal,
+    0x46: sim.sleepGoal,
   }[id];
 }
 

--- a/tests/sim-sources.test.ts
+++ b/tests/sim-sources.test.ts
@@ -6,6 +6,7 @@ import { test, expect } from "vitest";
 import {
   ID_METRIC,
   defaultSim,
+  goalOf,
   idValue,
   timeParts,
   type SimMetric,
@@ -34,6 +35,15 @@ test("sunrise/sunset split one time each into the hour/minute pair the face read
   expect([0x84, 0x85, 0x86, 0x87].map((id) => idValue(id, sun, t))).toEqual([5, 41, 18, 24]);
   // 12h device setting: the same evening sunset reads as 6, like the stock face's screenshot
   expect(idValue(0x86, { ...sun, is24h: false }, t)).toBe(6);
+});
+
+test("sleep splits into hours/minutes, and its ring reads the whole duration", () => {
+  const { sim, t } = at("steps", 0);
+  const slept = { ...sim, sleep: 7 * 60 + 36, sleepGoal: 8 * 60 };
+
+  expect([0x42, 0x43, 0x46].map((id) => idValue(id, slept, t))).toEqual([7, 36, 456]);
+  // the ring divides by the goal, so the duration and its denominator share one unit
+  expect(goalOf(0x46, slept)).toBe(480);
 });
 
 test("an override still wins over the metric field — that's what the folded section is for", () => {

--- a/tests/sim-sources.test.ts
+++ b/tests/sim-sources.test.ts
@@ -27,6 +27,15 @@ test.each(Object.entries(ID_METRIC))("0x%s reads its mapped metric", (idHex, met
   expect(idValue(id, low.sim, low.t)).not.toBe(idValue(id, high.sim, high.t));
 });
 
+test("sunrise/sunset split one time each into the hour/minute pair the face reads", () => {
+  const { sim, t } = at("steps", 0);
+  const sun = { ...sim, sunrise: 5 * 60 + 41, sunset: 18 * 60 + 24 };
+
+  expect([0x84, 0x85, 0x86, 0x87].map((id) => idValue(id, sun, t))).toEqual([5, 41, 18, 24]);
+  // 12h device setting: the same evening sunset reads as 6, like the stock face's screenshot
+  expect(idValue(0x86, { ...sun, is24h: false }, t)).toBe(6);
+});
+
 test("an override still wins over the metric field — that's what the folded section is for", () => {
   const { sim, t } = at("steps", 100);
 


### PR DESCRIPTION
The watch already feeds these — no bitmap baking needed.

Scanning all 101 stock faces turned up unlabelled data-source ids on `Default__280__Multifunction`, the face the issue points at. Two auto-layout groups flanking its sun arc (`x=41` and `x=377`, both `y=130`) are built exactly like the face's own clock group — hour, separator image, minute widget declaring `max=60` — and print the `05:41` / `06:24` its screenshot shows: `0x84..0x87` are sunrise and sunset. The same face reads `0x1b` beside its heart rate (98, blood oxygen) and `0x42`/`0x43` with a `0x46` ring for last night's sleep (`7.36H` against the wearer's goal).

So they are wired up like every other source: labelled in `ID_LABELS`, valued in `idValue`, and offered by the source picker with no extra UI. The simulator feeds sunrise/sunset/sleep one time field each instead of the six number boxes those ids would otherwise ask for, and the sleep ring divides by a goal like a steps ring does.

The hour sources appear to follow the device's 12/24h setting — that `06:24` is an evening sunset — so the sim's own 24-hour switch drives them; a per-id override still overrides.

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BbdLFi3m6wgXkK661n1JwT