### PR TITLE
Give every watchface its own page, instead of only a card in the grid

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,8 @@ pointing straight at PocketBase — no vite dev-server proxy involved), and fall
 same-origin (`location.origin`) without it, which is what prod uses — through Caddy on the
 same domain as the backend (see `fmc_pocketbase/README.md`).
 
-App: landing page (`/`), marketplace (`/market`, `/my`), watchface editor (`/editor`,
+App: landing page (`/`), marketplace (`/market`, `/market/[id]` — a face's showcase page,
+`/my`), watchface editor (`/editor`,
 with a BLE connection to the CMF Watch Pro 2) and auth (`/login`, `/register`).
 
 ## Architecture

--- a/src/lib/modules/market/components/watchface-card/watchface-card.svelte
+++ b/src/lib/modules/market/components/watchface-card/watchface-card.svelte
@@ -37,7 +37,7 @@
 
 <Card onClick={onOpen}>
   <div class="content">
-    <div class="preview" title="Open in editor">
+    <div class="preview" title="Open">
       <img src={fileUrl(wf, "preview")} alt={wf.name} loading="lazy" />
     </div>
     <div class="title-row">

--- a/src/lib/modules/market/model/market.api.ts
+++ b/src/lib/modules/market/model/market.api.ts
@@ -20,6 +20,18 @@ export const loadMarketFx = createEffect(async () => {
   return { items, likes };
 });
 
+// the showcase page (/market/[id]) is a deep link: it can be opened without the catalog ever
+// having been fetched, so it asks for its one record — plus that record's likes, which the
+// model folds into the shared $likes list
+export const loadWatchfaceFx = createEffect(async (id: string) => {
+  const [wf, likes] = await Promise.all([
+    pb.collection("watchfaces").getOne(id, { expand: "owner" }),
+    pb.collection("likes").getFullList({ filter: `watchface = '${id}'` }),
+  ]);
+
+  return { wf, likes };
+});
+
 export const loadMyFx = createEffect((userId: string) =>
   pb.collection("watchfaces").getFullList({ sort: "-updated", filter: `owner = '${userId}'` }),
 );

--- a/src/lib/modules/market/model/market.model.ts
+++ b/src/lib/modules/market/model/market.model.ts
@@ -47,6 +47,10 @@ export const $publishDialogOpen = createStore(false);
 // a page revisit reuses $items; reloading needs a full page refresh (or removeFx's own reload below)
 const $marketRequestedOnce = createStore(false);
 export const $likes = createStore<RecordModel[]>([]);
+// the single record behind the showcase page (/market/[id]) — refetched on every mount, so
+// it doesn't need patching when downloads/likes move elsewhere
+export const $watchface = createStore<RecordModel | null>(null);
+export const $watchfaceLoading = marketApi.loadWatchfaceFx.pending;
 export const $items = createStore<RecordModel[]>([]);
 export const $myItems = createStore<RecordModel[]>([]);
 export const $marketErr = createStore("");
@@ -66,6 +70,9 @@ export const saveDraftRequested = createEvent<marketApi.SavePayload>();
 export const publishRequested = createEvent<marketApi.SavePayload>();
 export const publishDialogOpened = createEvent();
 export const publishDialogClosed = createEvent();
+// showcase page: load one watchface by id, and open its page from a card
+export const watchfaceRequested = createEvent<string>();
+export const showcaseRequested = createEvent<RecordModel>();
 export const likeToggleRequested = createEvent<{
   wf: RecordModel;
   userId: string;
@@ -89,6 +96,7 @@ const saveFx = attach({
 });
 export const $savePending = saveFx.pending;
 const navigateToMarketFx = createEffect(() => goto("/market"));
+const navigateToShowcaseFx = createEffect((wf: RecordModel) => goto(`/market/${wf.id}`));
 // resolves the caller's existing like id from $likes so the api layer doesn't need to know about model state
 const toggleLikeFx = attach({
   source: $likes,
@@ -121,6 +129,36 @@ sample({
 sample({
   clock: myLoadRequested,
   target: marketApi.loadMyFx,
+});
+
+sample({
+  clock: showcaseRequested,
+  target: navigateToShowcaseFx,
+});
+
+sample({
+  clock: watchfaceRequested,
+  target: marketApi.loadWatchfaceFx,
+});
+// drop the previous record while the new one loads — otherwise navigating from one showcase
+// page to another shows the old face under the new id
+sample({
+  clock: watchfaceRequested,
+  fn: () => null,
+  target: $watchface,
+});
+sample({
+  clock: marketApi.loadWatchfaceFx.doneData,
+  fn: ({ wf }) => wf,
+  target: $watchface,
+});
+// fold this face's likes into the shared list, so the showcase page counts and toggles them
+// with the same $likes/likeToggleRequested the grid uses
+sample({
+  clock: marketApi.loadWatchfaceFx.doneData,
+  source: $likes,
+  fn: (all, { wf, likes }) => [...all.filter((l) => l.watchface !== wf.id), ...likes],
+  target: $likes,
 });
 
 sample({
@@ -351,6 +389,7 @@ sample({
   clock: [
     marketApi.loadMarketFx.failData,
     marketApi.loadMyFx.failData,
+    marketApi.loadWatchfaceFx.failData,
     toggleLikeFx.failData,
     marketApi.removeFx.failData,
     marketApi.togglePublishFx.failData,
@@ -386,4 +425,7 @@ sample({
 
 // any successful load clears the banner — otherwise a one-off failure (or a request the SDK
 // auto-cancelled) stayed on screen for the rest of the session, /my never reset it at all
-reset({ clock: [marketApi.loadMarketFx.done, marketApi.loadMyFx.done], target: $marketErr });
+reset({
+  clock: [marketApi.loadMarketFx.done, marketApi.loadMyFx.done, marketApi.loadWatchfaceFx.done],
+  target: $marketErr,
+});

--- a/src/lib/modules/market/pages/index.ts
+++ b/src/lib/modules/market/pages/index.ts
@@ -1,2 +1,3 @@
 export { default as MarketPage } from "./market.svelte";
 export { default as MyPage } from "./my.svelte";
+export { default as WatchfacePage } from "./watchface.svelte";

--- a/src/lib/modules/market/pages/market.svelte
+++ b/src/lib/modules/market/pages/market.svelte
@@ -4,6 +4,7 @@
   import { Skeleton } from "$lib/shared/components/skeleton";
   import { Icon } from "$lib/shared/components/icon";
   import type { RecordModel } from "pocketbase";
+  import { page } from "$app/state";
   import { authModel } from "$lib/modules/auth/model";
   import { marketModel } from "../model";
   import { WatchfaceCard } from "../components/watchface-card";
@@ -17,10 +18,17 @@
     marketLoadRequested,
     likeToggleRequested,
     removeRequested,
-    editRequested,
+    showcaseRequested,
   } = marketModel;
 
   marketLoadRequested();
+
+  // ?creator=<user id> — where a showcase page's creator link lands, until creators get
+  // profile pages of their own (issue #11)
+  const creator = $derived(page.url.searchParams.get("creator"));
+  const creatorName = $derived(
+    $items.find((wf) => wf.owner === creator)?.expand?.owner?.name || "this creator",
+  );
 
   let query = $state("");
   let sort = $state("new"); // new | popular | downloads
@@ -44,6 +52,7 @@
       // (fmc_pocketbase 1753500000_hide_catalog.js); the guard stays so a stale
       // cached list can't render them either
       .filter((wf) => Boolean(wf.owner))
+      .filter((wf) => !creator || wf.owner === creator)
       .filter((wf) => wf.name.toLowerCase().includes(query.trim().toLowerCase()))
       .toSorted((a, b) =>
         // popular = most liked; downloads used to be mixed in here, which just made this
@@ -66,6 +75,7 @@
   $effect(() => {
     query;
     sort;
+    creator;
     visibleCount = PAGE;
   });
   /* oxlint-enable no-unused-expressions */
@@ -83,6 +93,13 @@
 
 <div class="page">
   {#if $marketErr}<p class="error">{$marketErr}</p>{/if}
+
+  {#if creator}
+    <p class="filter">
+      Watchfaces by {creatorName}
+      <a href="/market">Show all</a>
+    </p>
+  {/if}
 
   <div class="toolbar">
     <div class="search">
@@ -113,7 +130,7 @@
           liked={!!myLike(wf.id)}
           canLike={!!$user}
           canRemove={$user?.id === wf.owner}
-          onOpen={() => editRequested(wf)}
+          onOpen={() => showcaseRequested(wf)}
           onLike={() => $user && likeToggleRequested({ wf, userId: $user.id })}
           onRemove={() => remove(wf)}
         />
@@ -138,6 +155,19 @@
     padding: 0.75rem 1rem 0;
     font-size: 0.75rem;
     color: var(--color-error);
+  }
+  .filter {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin: 0;
+    padding: 0.75rem 1rem 0;
+    font-size: 0.75rem;
+    color: oklch(from var(--color-text) l c h / 55%);
+
+    a {
+      color: var(--color-accent);
+    }
   }
   .toolbar {
     display: flex;

--- a/src/lib/modules/market/pages/watchface.svelte
+++ b/src/lib/modules/market/pages/watchface.svelte
@@ -1,0 +1,322 @@
+<script lang="ts">
+  import { Avatar } from "$lib/shared/components/avatar";
+  import { Badge } from "$lib/shared/components/badge";
+  import { Button } from "$lib/shared/components/button";
+  import { Icon } from "$lib/shared/components/icon";
+  import { Skeleton } from "$lib/shared/components/skeleton";
+  import { downloadUrl, fileUrl } from "$lib/shared/api";
+  import { authModel } from "$lib/modules/auth/model";
+  import { marketModel } from "../model";
+
+  interface Props {
+    id: string;
+  }
+  const { id }: Props = $props();
+
+  const { $user: user } = authModel;
+  const {
+    $watchface: watchface,
+    $watchfaceLoading: loading,
+    $likes: likes,
+    $marketErr: marketErr,
+    watchfaceRequested,
+    likeToggleRequested,
+    editRequested,
+  } = marketModel;
+
+  $effect(() => {
+    watchfaceRequested(id);
+  });
+
+  const wf = $derived($watchface);
+  const owner = $derived(wf?.expand?.owner);
+  const likeCount = $derived($likes.filter((l) => l.watchface === id).length);
+  const liked = $derived($likes.some((l) => l.watchface === id && l.user === $user?.id));
+  const day = (v: string) => new Date(v).toLocaleDateString();
+
+  // ponytail: Web Share where it exists, clipboard everywhere else — no share-sheet dependency
+  let copied = $state(false);
+
+  async function share() {
+    const url = location.href;
+
+    if (navigator.share) {
+      // a dismissed share sheet rejects — that's a cancel, not an error
+      await navigator.share({ title: wf?.name, url }).catch(() => {});
+      return;
+    }
+    await navigator.clipboard.writeText(url);
+    copied = true;
+  }
+</script>
+
+<svelte:head><title>{wf?.name || "Watchface"} — FMC Watchfaces</title></svelte:head>
+
+<div class="page">
+  {#if $marketErr}<p class="error">{$marketErr}</p>{/if}
+
+  <main>
+    <!-- ponytail: no back-arrow glyph in the icon registry, and "←" needs no import -->
+    <a class="back" href="/market">← Marketplace</a>
+
+    {#if wf}
+      <article class="face">
+        <div class="preview">
+          <img src={fileUrl(wf, "preview")} alt={wf.name} />
+        </div>
+
+        <div class="info">
+          <div class="title-row">
+            <h1 class="name">{wf.name}</h1>
+            {#if wf.type}<Badge>{wf.type}</Badge>{/if}
+          </div>
+
+          {#if owner}
+            <a class="creator" href="/market?creator={wf.owner}" title="Watchfaces by this creator">
+              <Avatar name={owner.name || "?"} size={36} />
+              <span class="creator-text">
+                <span class="creator-name">{owner.name || "Unknown"}</span>
+                <span class="creator-hint">See all their watchfaces</span>
+              </span>
+            </a>
+          {/if}
+
+          {#if wf.description}
+            <p class="desc">{wf.description}</p>
+          {:else}
+            <p class="desc muted">No description.</p>
+          {/if}
+
+          <dl class="stats">
+            <div>
+              <dt>Likes</dt>
+              <dd>{likeCount}</dd>
+            </div>
+            <div>
+              <dt>Downloads</dt>
+              <dd>{wf.downloads || 0}</dd>
+            </div>
+            <div>
+              <dt>Flashed</dt>
+              <dd>{wf.flashes || 0}</dd>
+            </div>
+            <div>
+              <dt>Published</dt>
+              <dd>{day(wf.created)}</dd>
+            </div>
+            <div>
+              <dt>Updated</dt>
+              <dd>{day(wf.updated)}</dd>
+            </div>
+          </dl>
+
+          <div class="actions">
+            <Button onClick={() => editRequested(wf)}>
+              <Icon name="pencil" size={16} />
+              Open in editor
+            </Button>
+            <a class="link-action" href={downloadUrl(wf)}>
+              <Icon name="download" size={16} />
+              Download .bin
+            </a>
+            <span class="action-slot" title={$user ? "Like" : "Sign in to like"}>
+              <Button
+                kind="secondary"
+                disabled={!$user}
+                onClick={() => $user && likeToggleRequested({ wf, userId: $user.id })}
+              >
+                <Icon
+                  name="heart"
+                  size={16}
+                  color={liked ? "var(--color-error)" : undefined}
+                  fill={liked ? "var(--color-error)" : "none"}
+                />
+                {likeCount}
+              </Button>
+            </span>
+            <Button kind="secondary" onClick={share}>
+              <Icon name="link" size={16} />
+              {copied ? "Link copied" : "Share"}
+            </Button>
+          </div>
+        </div>
+      </article>
+    {:else if $loading}
+      <div class="face">
+        <Skeleton height="17.5rem" />
+        <div class="info">
+          <Skeleton height="1.75rem" width="60%" />
+          <Skeleton height="2.25rem" width="40%" />
+          <Skeleton height="3rem" />
+        </div>
+      </div>
+    {:else}
+      <p class="empty">Watchface not found.</p>
+    {/if}
+  </main>
+</div>
+
+<style>
+  .page {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+  }
+  .error {
+    margin: 0;
+    padding: 0.75rem 1rem 0;
+    font-size: 0.75rem;
+    color: var(--color-error);
+  }
+  main {
+    flex: 1;
+    overflow-y: auto;
+    /* the extra bottom padding keeps the action row clear of the mobile tab bar */
+    padding: 1rem 1rem 2rem;
+  }
+  .back {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    font-size: 0.75rem;
+    color: oklch(from var(--color-text) l c h / 55%);
+    text-decoration: none;
+
+    &:hover {
+      color: var(--color-text);
+    }
+  }
+  .face {
+    display: grid;
+    grid-template-columns: minmax(0, 20rem) minmax(0, 1fr);
+    align-items: start;
+    gap: 2rem;
+    max-width: 56rem;
+    margin: 1rem auto 0;
+  }
+  .preview {
+    aspect-ratio: 1 / 1;
+    overflow: hidden;
+    border-radius: 625rem;
+    background: oklch(0 0 0);
+
+    img {
+      display: block;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+  }
+  .info {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+  .title-row {
+    display: flex;
+    align-items: baseline;
+    gap: 0.75rem;
+  }
+  .name {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: 2rem;
+    font-weight: 400;
+  }
+  .creator {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.625rem;
+    align-self: flex-start;
+    padding: 0.375rem 0.75rem 0.375rem 0.375rem;
+    border-radius: var(--border-radius);
+    color: var(--color-text);
+    text-decoration: none;
+    background: oklch(from var(--color-text) l c h / 6%);
+
+    &:hover {
+      background: oklch(from var(--color-text) l c h / 12%);
+    }
+  }
+  .creator-text {
+    display: flex;
+    flex-direction: column;
+  }
+  .creator-name {
+    font-size: 0.875rem;
+    font-weight: 500;
+  }
+  .creator-hint {
+    font-size: 0.625rem;
+    color: oklch(from var(--color-text) l c h / 55%);
+  }
+  .desc {
+    margin: 0;
+    white-space: pre-wrap;
+    font-size: 0.875rem;
+  }
+  .muted {
+    color: oklch(from var(--color-text) l c h / 55%);
+  }
+  .stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(6rem, 1fr));
+    gap: 0.75rem;
+    margin: 0;
+    padding: 0.75rem 0;
+    border-top: 1px solid oklch(from var(--color-text) l c h / 12%);
+    border-bottom: 1px solid oklch(from var(--color-text) l c h / 12%);
+
+    dt {
+      font-size: 0.625rem;
+      color: oklch(from var(--color-text) l c h / 55%);
+    }
+    dd {
+      margin: 0;
+      font-size: 0.875rem;
+    }
+  }
+  .actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
+  }
+  .action-slot {
+    display: inline-flex;
+  }
+  .link-action {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    height: 1.875rem;
+    padding: 0 0.625rem;
+    border-radius: var(--border-radius);
+    color: var(--color-text);
+    background-color: oklch(from var(--color-text) l c h / 12%);
+    text-decoration: none;
+    font-size: 0.75rem;
+    font-weight: 500;
+    transition: background-color 0.15s ease;
+
+    &:hover {
+      background-color: oklch(from var(--color-text) l c h / 20%);
+    }
+  }
+  .empty {
+    padding: 4rem 0;
+    text-align: center;
+    font-size: 0.75rem;
+    color: oklch(from var(--color-text) l c h / 55%);
+  }
+  @media (max-width: 767px) {
+    .face {
+      grid-template-columns: minmax(0, 1fr);
+      gap: 1.25rem;
+    }
+    .preview {
+      max-width: 15rem;
+      margin-inline: auto;
+    }
+  }
+</style>

--- a/src/routes/(app)/market/[id]/+page.svelte
+++ b/src/routes/(app)/market/[id]/+page.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  import { page } from "$app/state";
+  import { WatchfacePage } from "$lib/modules/market/pages";
+</script>
+
+<WatchfacePage id={page.params.id ?? ""} />


### PR DESCRIPTION
A card click opened the editor, so a face had no address to share and nothing to read
before loading it. `/market/[id]` is that address: large preview, creator, description,
and the counters the backend already keeps (likes, downloads, flashes, publish/update
dates), with open-in-editor, download, like and share next to them.

The page is a deep link, so it fetches its one record (`loadWatchfaceFx`) rather than
waiting for the catalog; that record's likes fold into the shared `$likes`, so counting
and toggling stay the grid's code. The market grid now opens the showcase page instead
of the editor, and `?creator=<id>` filters it — that's where the creator link lands until
creators get pages of their own (#11).

Built against the current PocketBase schema only. Still needs backend work, out of scope
here: tags/categories (no field), comments (no collection), installs as a counter separate
from `downloads`, favorites/collections and follows (no collections), a screenshot gallery
(`preview` is `maxSelect: 1`), and creator profile pages (#11).

Verified: `pnpm lint`, `format:check`, `check`, `test` (192/192) and `build` all pass, plus
a headless Chromium run against the live backend — card → showcase → creator filter, clean
console, desktop and mobile viewports.

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DKKsvh89YYBTbnXvJJuPK