### PR TITLE
Add an AOD preview toggle to the watchface showcase page

### DIFF
--- a/src/lib/modules/market/components/live-dial/live-dial.svelte
+++ b/src/lib/modules/market/components/live-dial/live-dial.svelte
@@ -8,8 +8,10 @@
 
   interface Props {
     face: LiveFace;
+    /** which screen of the face to draw — a face without an AOD one falls back to the main screen */
+    screen?: "main" | "aod";
   }
-  const { face }: Props = $props();
+  const { face, screen = "main" }: Props = $props();
 
   let canvas = $state<HTMLCanvasElement>();
   // no panel to change it here, so one sim for the lifetime of the component — `live` makes
@@ -22,10 +24,11 @@
     if (!ctx) return;
     // read here, not inside the loop: the loop must not re-run the effect
     const { doc, store } = face;
+    const kind = screen;
     let raf = 0;
     const loop = () => {
       ctx.clearRect(0, 0, SCREEN, SCREEN);
-      renderDoc(ctx, doc, store, "main", sim);
+      renderDoc(ctx, doc, store, kind, sim);
       // ponytail: a plain rAF, like the editor's canvas — drop to a timer if a market page ever
       // needs to run several of these at once
       raf = requestAnimationFrame(loop);

--- a/src/lib/modules/market/model/market.model.ts
+++ b/src/lib/modules/market/model/market.model.ts
@@ -60,6 +60,11 @@ export interface LiveFace {
   store: ImageStore;
 }
 export const $live = createStore<LiveFace | null>(null);
+/** Which screen of that face the showcase preview draws. */
+export const $dialScreen = createStore<"main" | "aod">("main");
+// no AOD screen means renderDoc would fall back to the main one — nothing to switch to, so the
+// page doesn't offer the toggle at all
+export const $hasAod = $live.map((live) => Boolean(live?.doc.screens.some((s) => s.kind === "aod")));
 // the same bytes an install sends — fetched once, whichever happens first
 const $bin = createStore<Uint8Array | null>(null);
 export const $likes = createStore<RecordModel[]>([]);
@@ -97,6 +102,8 @@ export const publishDialogClosed = createEvent();
 // showcase page: load one watchface by id, and open its page from a card
 export const watchfaceRequested = createEvent<string>();
 export const showcaseRequested = createEvent<RecordModel>();
+// showcase page: switch the preview between the normal render and the always-on one
+export const dialScreenSet = createEvent<"main" | "aod">();
 export const likeToggleRequested = createEvent<{
   wf: RecordModel;
   userId: string;
@@ -260,7 +267,12 @@ sample({
 });
 
 // a different face on screen than the one that was just installed
-reset({ clock: watchfaceRequested, target: [$installed, $live, $bin] });
+reset({ clock: watchfaceRequested, target: [$installed, $live, $bin, $dialScreen] });
+
+sample({
+  clock: dialScreenSet,
+  target: $dialScreen,
+});
 
 // the page draws the dial for real: fetch the file, parse it, decode its pixels
 sample({

--- a/src/lib/modules/market/pages/watchface.svelte
+++ b/src/lib/modules/market/pages/watchface.svelte
@@ -22,6 +22,8 @@
     $watchface: watchface,
     $watchfaceLoading: loading,
     $live: live,
+    $dialScreen: dialScreen,
+    $hasAod: hasAod,
     $installing: installing,
     $installed: installed,
     $likes: likes,
@@ -30,6 +32,7 @@
     installRequested,
     likeToggleRequested,
     editRequested,
+    dialScreenSet,
   } = marketModel;
   const {
     $bleInfo: bleInfo,
@@ -75,12 +78,24 @@
 
     {#if wf}
       <article class="face">
-        <div class="preview">
-          <!-- the still preview holds the spot until the file is parsed, and stays if it can't be -->
-          {#if $live}
-            <LiveDial face={$live} />
-          {:else}
-            <img src={fileUrl(wf, "preview")} alt={wf.name} />
+        <div class="dial">
+          <div class="preview">
+            <!-- the still preview holds the spot until the file is parsed, and stays if it can't be -->
+            {#if $live}
+              <LiveDial face={$live} screen={$dialScreen} />
+            {:else}
+              <img src={fileUrl(wf, "preview")} alt={wf.name} />
+            {/if}
+          </div>
+
+          {#if $hasAod}
+            <Button
+              kind="secondary"
+              onClick={() => dialScreenSet($dialScreen === "aod" ? "main" : "aod")}
+            >
+              <Icon name={$dialScreen === "aod" ? "monitor" : "moon"} size={16} />
+              {$dialScreen === "aod" ? "Show normal" : "Show always-on"}
+            </Button>
           {/if}
         </div>
 
@@ -237,7 +252,14 @@
     max-width: 56rem;
     margin: 1rem auto 0;
   }
+  .dial {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.75rem;
+  }
   .preview {
+    width: 100%;
     aspect-ratio: 1 / 1;
     overflow: hidden;
     border-radius: 625rem;


### PR DESCRIPTION
The showcase page (`/market/[id]`) drew the main screen of the face only. Faces that carry an always-on screen now get a button under the dial that switches the live render between the two.

- `market.model.ts`: `$dialScreen` + `dialScreenSet`, and `$hasAod` derived from `$live` — a face without an AOD screen would just fall back to the main one, so the page doesn't offer the toggle. Reset alongside `$live`/`$bin` on `watchfaceRequested`.
- `live-dial.svelte`: a `screen` prop handed to `renderDoc` (read before the rAF loop, so the loop doesn't re-run the effect).
- `watchface.svelte`: the toggle button, view only.

`npm run check` and `npm run build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4XzJpa6bUvX6ZATdiQ758