### PR TITLE
Format market.model.ts

### DIFF
--- a/src/lib/modules/market/model/market.model.ts
+++ b/src/lib/modules/market/model/market.model.ts
@@ -64,7 +64,9 @@ export const $live = createStore<LiveFace | null>(null);
 export const $dialScreen = createStore<"main" | "aod">("main");
 // no AOD screen means renderDoc would fall back to the main one — nothing to switch to, so the
 // page doesn't offer the toggle at all
-export const $hasAod = $live.map((live) => Boolean(live?.doc.screens.some((s) => s.kind === "aod")));
+export const $hasAod = $live.map((live) =>
+  Boolean(live?.doc.screens.some((s) => s.kind === "aod")),
+);
 // the same bytes an install sends — fetched once, whichever happens first
 const $bin = createStore<Uint8Array | null>(null);
 export const $likes = createStore<RecordModel[]>([]);


### PR DESCRIPTION
The AOD toggle merge (#36) left `market.model.ts` unformatted: CI on `main` failed at `pnpm format:check`, so the `deploy` job was skipped and the AOD toggle never reached the VPS.

`oxfmt` wraps the `$hasAod` map callback. No behaviour change.

Merging this makes `main` green again and triggers the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T7a23aPfAZMMkGFox8FxJo