### PR TITLE
Write progress rings in the shape the watch actually draws

### DIFF
--- a/src/lib/modules/editor/components/props/source.svelte
+++ b/src/lib/modules/editor/components/props/source.svelte
@@ -66,9 +66,15 @@
 
   // meta.flags === 4 marks this widget's assets accent-tintable on the real device — see
   // docs/cmf-protocol.md "Accent color". Every non-transparent pixel gets swapped, regardless of
-  // its baked color, so this works on any art.
+  // its baked color, so this works on any art. Byte 4 is not a red channel here but which accent
+  // the watch hands over: 206 accent widgets across the corpus, and not one of them leaves it at
+  // 0 — so turning the flag on has to pick a slot too, or the widget is flagged for a color that
+  // doesn't exist (#37).
   const setAccent = (on: boolean) =>
-    meta && set(layer.id, { meta: { ...meta, flags: on ? 4 : 0 } } as Partial<Layer>);
+    meta &&
+    set(layer.id, {
+      meta: { ...meta, flags: on ? 4 : 0, rgb: on ? [meta.rgb[0] || 1, 0, 0] : meta.rgb },
+    } as Partial<Layer>);
 
   const setSpec = (patch: Partial<ArcSpec>) =>
     ring && set(ring.id, { spec: { ...ring.spec, ...patch } } as Partial<Layer>);

--- a/src/lib/modules/editor/core/document/doc.ts
+++ b/src/lib/modules/editor/core/document/doc.ts
@@ -17,7 +17,7 @@ import {
   type Resource,
 } from "../format";
 import { buildBind, parseBind, type BindEntry } from "./sources";
-import { arcSpecHex, parseArcSpec, type ArcSpec } from "../render/arc";
+import { ARC_REST, arcSpecHex, parseArcSpec, type ArcSpec } from "../render/arc";
 
 // Branded: a bare number index is exactly what let positional bugs (shared runs, orphaned
 // resources, a duplicate silently sharing its original's pixels) through unnoticed.
@@ -439,7 +439,25 @@ const frameHex = (f: Frame) => {
   return hex(out);
 };
 
-function toNode(l: Layer, runAt: ReadonlyMap<string, number[]>): FaceNode {
+/** Every imageless ring in the corpus — and so every one the watch is known to draw — is a 0x5b
+ *  spec carrying its 3 trailing bytes, under a struct padded 2 bytes past the meta. The editor
+ *  used to mint a bare 16-byte 0x5a under an 18-byte struct: a shape no stock file has, and the
+ *  watch silently skipped it (#37). Repaired here rather than only in the factory, so a ring
+ *  already sitting in a document is fixed by re-exporting it. 0x5b has nowhere to put a radius,
+ *  so the editor's live one moves into meta.w/h — where the reader picks it back up. */
+function bareRing(l: RingLayer): RingLayer {
+  const r = l.spec.radius;
+
+  return {
+    ...l,
+    tail: l.tail ?? "0000",
+    ...(r && !l.meta.auto ? { meta: { ...l.meta, w: 2 * r, h: 2 * r } } : {}),
+    spec: { ...l.spec, kind: TAG.arcClipped, radius: 0, rest: l.spec.rest ?? ARC_REST },
+  };
+}
+
+function toNode(layer: Layer, runAt: ReadonlyMap<string, number[]>): FaceNode {
+  const l = layer.kind === "ring" && !layer.frames.length ? bareRing(layer) : layer;
   const subs: FaceNode[] = [];
   const imgs = (f: readonly ImageId[]) => runAt.get(f.join(" "))!;
 

--- a/src/lib/modules/editor/core/document/doc.ts
+++ b/src/lib/modules/editor/core/document/doc.ts
@@ -290,6 +290,34 @@ const SERVICE = new Set<number>([
   TAG.slot,
 ]);
 
+/** A ring with no art is nothing but a stroke, so where its color comes from is not decoration.
+ *  Byte 7 says which: 1 = the rgb in bytes 4..6 (and then byte 8 is 0xff), 4 = the wearer's
+ *  accent, whose slot is byte 4 — 1, 2 or 4 in all 206 accent widgets of the corpus, never 0.
+ *  The editor wrote byte 7 = 0, or 4 over a zero byte 4: no color to stroke with either way. */
+const ringMeta = (m: WidgetMeta): WidgetMeta =>
+  m.flags === 1 ? m : { ...m, flags: 4, rgb: [m.rgb[0] || 1, 0, 0], reserved: 0 };
+
+/** Every imageless ring in the corpus — and so every one the watch is known to draw — is a 0x5b
+ *  spec carrying its 3 trailing bytes, under a struct padded 2 bytes past the meta. The editor
+ *  used to mint a bare 16-byte 0x5a under an 18-byte struct: a shape no stock file has, and the
+ *  watch silently skipped it (#37). Applied in both directions — on the way in, so opening an
+ *  affected face repairs it in front of the author, and on the way out, so nothing else can put a
+ *  ring the watch won't draw into a file. 0x5b has nowhere to put a radius, so the editor's live
+ *  one moves into meta.w/h — where the reader picks it back up. */
+function bareRing(l: RingLayer): RingLayer {
+  const r = l.spec.radius;
+  const meta = ringMeta(r && !l.meta.auto ? { ...l.meta, w: 2 * r, h: 2 * r } : l.meta);
+
+  return {
+    ...l,
+    // `||`, not `??`: a spec parsed off a file the editor itself wrote has an empty rest, not a
+    // missing one — parseArcSpec hands back whatever was past the body, and there was nothing
+    tail: l.tail || "0000",
+    meta,
+    spec: { ...l.spec, kind: TAG.arcClipped, radius: 0, rest: l.spec.rest || ARC_REST },
+  };
+}
+
 /** A digit strip is tagged 0x60 in most faces, but the renderer also treats any node with a
  *  `fmt` sibling over a 10-glyph atlas as one — mirror that, so `kind` matches what's drawn. */
 const isDigits = (n: FaceNode, frames: readonly ImageId[]) =>
@@ -346,7 +374,11 @@ function toLayer(n: FaceNode, ids: readonly ImageId[]): Layer {
         pivotY: pivot.pivotY ?? 0,
         pivotFlag: pivot.flag ?? 0,
       };
-    if (spec) return { ...placed, kind: "ring", spec, frames };
+    if (spec) {
+      const ring: RingLayer = { ...placed, kind: "ring", spec, frames };
+
+      return frames.length ? ring : bareRing(ring);
+    }
     if (slot) {
       const v = unhex(slot.hex ?? "");
 
@@ -445,25 +477,6 @@ const frameHex = (f: Frame) => {
  *  watch silently skipped it (#37). Repaired here rather than only in the factory, so a ring
  *  already sitting in a document is fixed by re-exporting it. 0x5b has nowhere to put a radius,
  *  so the editor's live one moves into meta.w/h — where the reader picks it back up. */
-/** A ring with no art is nothing but a stroke, so where its color comes from is not decoration.
- *  Byte 7 says which: 1 = the rgb in bytes 4..6 (and then byte 8 is 0xff), 4 = the wearer's
- *  accent, whose slot is byte 4 — 1, 2 or 4 in all 206 accent widgets of the corpus, never 0.
- *  The editor wrote byte 7 = 0, or 4 over a zero byte 4: no color to stroke with either way. */
-const ringMeta = (m: WidgetMeta): WidgetMeta =>
-  m.flags === 1 ? m : { ...m, flags: 4, rgb: [m.rgb[0] || 1, 0, 0], reserved: 0 };
-
-function bareRing(l: RingLayer): RingLayer {
-  const r = l.spec.radius;
-  const meta = ringMeta(r && !l.meta.auto ? { ...l.meta, w: 2 * r, h: 2 * r } : l.meta);
-
-  return {
-    ...l,
-    tail: l.tail ?? "0000",
-    meta,
-    spec: { ...l.spec, kind: TAG.arcClipped, radius: 0, rest: l.spec.rest ?? ARC_REST },
-  };
-}
-
 function toNode(layer: Layer, runAt: ReadonlyMap<string, number[]>): FaceNode {
   const l = layer.kind === "ring" && !layer.frames.length ? bareRing(layer) : layer;
   const subs: FaceNode[] = [];

--- a/src/lib/modules/editor/core/document/doc.ts
+++ b/src/lib/modules/editor/core/document/doc.ts
@@ -445,13 +445,21 @@ const frameHex = (f: Frame) => {
  *  watch silently skipped it (#37). Repaired here rather than only in the factory, so a ring
  *  already sitting in a document is fixed by re-exporting it. 0x5b has nowhere to put a radius,
  *  so the editor's live one moves into meta.w/h — where the reader picks it back up. */
+/** A ring with no art is nothing but a stroke, so where its color comes from is not decoration.
+ *  Byte 7 says which: 1 = the rgb in bytes 4..6 (and then byte 8 is 0xff), 4 = the wearer's
+ *  accent, whose slot is byte 4 — 1, 2 or 4 in all 206 accent widgets of the corpus, never 0.
+ *  The editor wrote byte 7 = 0, or 4 over a zero byte 4: no color to stroke with either way. */
+const ringMeta = (m: WidgetMeta): WidgetMeta =>
+  m.flags === 1 ? m : { ...m, flags: 4, rgb: [m.rgb[0] || 1, 0, 0], reserved: 0 };
+
 function bareRing(l: RingLayer): RingLayer {
   const r = l.spec.radius;
+  const meta = ringMeta(r && !l.meta.auto ? { ...l.meta, w: 2 * r, h: 2 * r } : l.meta);
 
   return {
     ...l,
     tail: l.tail ?? "0000",
-    ...(r && !l.meta.auto ? { meta: { ...l.meta, w: 2 * r, h: 2 * r } } : {}),
+    meta,
     spec: { ...l.spec, kind: TAG.arcClipped, radius: 0, rest: l.spec.rest ?? ARC_REST },
   };
 }

--- a/src/lib/modules/editor/core/document/factory.ts
+++ b/src/lib/modules/editor/core/document/factory.ts
@@ -4,7 +4,7 @@
 // ring gauges, which metrics a slot offers.
 
 import { CENTER, SCREEN } from "../render/screen";
-import type { ArcSpec } from "../render/arc";
+import { ARC_REST, type ArcSpec } from "../render/arc";
 import {
   newImageId,
   newNodeId,
@@ -96,18 +96,21 @@ export const newGroup = (): GroupLayer => ({
   children: [],
 });
 
-/** A procedural progress ring: no bitmap at all — geometry and gauge live in the 0x5a spec, the
- *  stroke color follows the device accent (meta flags left at 0, see arc.ts). */
+/** A procedural progress ring: no bitmap at all — geometry and gauge live in the arc spec, the
+ *  stroke color follows the device accent (meta flags left at 0, see arc.ts). 0x5b with the
+ *  corpus's trailing bytes and a 2-byte struct tail is the shape the watch draws; `radius` is
+ *  editor-side only from here on (0x5b writes none — see bareRing in doc.ts). */
 export function newRing(): RingLayer {
   const d = 200;
   const spec: ArcSpec = {
-    kind: TAG.arc,
+    kind: TAG.arcClipped,
     min: 0,
     max: 100,
     start: 0,
     end: 360,
     width: 10,
     radius: d / 2,
+    rest: ARC_REST,
   };
 
   return {
@@ -117,6 +120,7 @@ export function newRing(): RingLayer {
     x: CENTER - d / 2,
     y: CENTER - d / 2,
     meta: metaWith({ w: d, h: d, source: 0x19, max: 100 }), // steps, as a percent-of-goal gauge
+    tail: "0000",
     spec,
     frames: [],
   };

--- a/src/lib/modules/editor/core/document/factory.ts
+++ b/src/lib/modules/editor/core/document/factory.ts
@@ -97,9 +97,9 @@ export const newGroup = (): GroupLayer => ({
 });
 
 /** A procedural progress ring: no bitmap at all — geometry and gauge live in the arc spec, the
- *  stroke color follows the device accent (meta flags left at 0, see arc.ts). 0x5b with the
- *  corpus's trailing bytes and a 2-byte struct tail is the shape the watch draws; `radius` is
- *  editor-side only from here on (0x5b writes none — see bareRing in doc.ts). */
+ *  stroke color follows the device accent. 0x5b with the corpus's trailing bytes and a 2-byte
+ *  struct tail is the shape the watch draws; `radius` is editor-side only from here on (0x5b
+ *  writes none — see bareRing in doc.ts). */
 export function newRing(): RingLayer {
   const d = 200;
   const spec: ArcSpec = {
@@ -119,7 +119,9 @@ export function newRing(): RingLayer {
     kind: "ring",
     x: CENTER - d / 2,
     y: CENTER - d / 2,
-    meta: metaWith({ w: d, h: d, source: 0x19, max: 100 }), // steps, as a percent-of-goal gauge
+    // steps, as a percent-of-goal gauge; flags 4 + byte 4 = accent slot 1, the same color source
+    // every stock imageless ring uses (a ring with no art has nothing else to stroke with)
+    meta: metaWith({ w: d, h: d, source: 0x19, max: 100, flags: 4, rgb: [1, 0, 0] }),
     tail: "0000",
     spec,
     frames: [],

--- a/src/lib/modules/editor/core/render/arc.ts
+++ b/src/lib/modules/editor/core/render/arc.ts
@@ -18,6 +18,12 @@ export interface ArcSpec {
   rest?: string;
 }
 
+/** The 3 bytes every arc in the corpus carries past the body we decode: `01 00` and a byte that
+ *  varies per file without any pattern we can read. Written verbatim on a spec that has none of
+ *  its own — the watch skips a ring whose spec node is short (#37). Copied from Combo's imageless
+ *  battery ring, the closest stock widget to the one the editor mints. */
+export const ARC_REST = "010068";
+
 /** 0x5a/0x5b body: min i32 ‖ max i32 ‖ start i16 (0.1°) ‖ end i16 ‖ width u16 ‖ radius u16. */
 export function parseArcSpec(node: FaceNode): ArcSpec | null {
   const sp = node.subs?.find((n) => n.tag === TAG.arc || n.tag === TAG.arcClipped);

--- a/tests/doc-factory.test.ts
+++ b/tests/doc-factory.test.ts
@@ -3,9 +3,16 @@
 // editor-new-nodes.browser.test.ts; this pins the one path that has no widget in it at all: a
 // blank document, which is what "New" produces.
 import { test, expect } from "vitest";
-import { buildBin, parseBin, TAG, type Resource } from "../src/lib/modules/editor/core/format";
+import { readFileSync } from "node:fs";
+import {
+  buildBin,
+  parseBin,
+  TAG,
+  type FaceNode,
+  type Resource,
+} from "../src/lib/modules/editor/core/format";
 import { toLegacy } from "../src/lib/modules/editor/core/document/doc";
-import { blankDoc, withName } from "../src/lib/modules/editor/core/document/factory";
+import { blankDoc, newRing, withName } from "../src/lib/modules/editor/core/document/factory";
 import { SCREEN } from "../src/lib/modules/editor/core/render/screen";
 
 const res = (w: number, h: number): Resource => ({
@@ -27,6 +34,38 @@ test("a blank document builds into a parseable file with both of its assets", ()
   expect(built.screens).toHaveLength(1);
   expect(built.screens[0].tag).toBe(TAG.main);
   expect(built.screens[0].subs!.map((n) => n.tag)).toEqual([TAG.name, TAG.preview, 0x30]);
+});
+
+// #37: a ring that renders in the editor but is missing on the watch. The editor wrote a shape
+// no stock file has — a 16-byte 0x5a spec under an 18-byte struct — and the watch skipped it.
+// Pinned against a stock imageless ring (Combo's battery ring) rather than against literal
+// numbers: the shape has to keep matching a file the firmware is known to draw.
+const ringShape = (n: FaceNode) => {
+  const st = n.subs!.find((s) => s.tag === TAG.struct)!;
+  const spec = n.subs!.find((s) => s.tag === TAG.arc || s.tag === TAG.arcClipped)!;
+
+  return { subs: n.subs!.map((s) => s.tag), tail: st.tail, specBytes: spec.hex!.length / 2 };
+};
+
+test("a fresh ring is written in the same node shape as a stock imageless ring", () => {
+  const doc = blankDoc("Ring", res(2, 2), res(SCREEN, SCREEN));
+  const screen = doc.screens[0];
+  const built = parseBin(
+    buildBin(toLegacy({ ...doc, screens: [{ ...screen, layers: [...screen.layers, newRing()] }] })),
+  );
+  const written = built.screens[0].subs!.find((n) => n.tag === 0x81)!;
+
+  const stock = parseBin(readFileSync("tests/__fixtures__/Multifunction__366__Combo.bin"));
+  const bare: FaceNode[] = [];
+  const walk = (n: FaceNode) => {
+    const st = n.subs?.find((s) => s.tag === TAG.struct);
+
+    if (st && !st.images && n.subs!.some((s) => s.tag === TAG.arcClipped)) bare.push(n);
+    n.subs?.forEach(walk);
+  };
+
+  stock.screens.forEach(walk);
+  expect(ringShape(written)).toEqual(ringShape(bare[0]));
 });
 
 // The name lives in the 16-byte header field (cut to 15 bytes) and in the 0x86 node, while

--- a/tests/doc-factory.test.ts
+++ b/tests/doc-factory.test.ts
@@ -11,7 +11,7 @@ import {
   type FaceNode,
   type Resource,
 } from "../src/lib/modules/editor/core/format";
-import { toLegacy } from "../src/lib/modules/editor/core/document/doc";
+import { toLegacy, type RingLayer } from "../src/lib/modules/editor/core/document/doc";
 import { blankDoc, newRing, withName } from "../src/lib/modules/editor/core/document/factory";
 import { SCREEN } from "../src/lib/modules/editor/core/render/screen";
 
@@ -53,11 +53,27 @@ const ringShape = (n: FaceNode) => {
   };
 };
 
-test("a fresh ring is written in the same node shape as a stock imageless ring", () => {
+/** What builds before the fix put in a file: a 0x5a spec with nothing past its body, no struct
+ *  tail, and a meta with no color source. Opening such a face has to repair it. */
+const legacyRing = (): RingLayer => {
+  const r = newRing();
+
+  return {
+    ...r,
+    tail: "",
+    meta: { ...r.meta, flags: 0, rgb: [0, 0, 0] },
+    spec: { ...r.spec, kind: TAG.arc, rest: "" },
+  };
+};
+
+test.each([
+  ["fresh", newRing],
+  ["legacy", legacyRing],
+])("a %s ring is written in the same node shape as a stock imageless ring", (_label, make) => {
   const doc = blankDoc("Ring", res(2, 2), res(SCREEN, SCREEN));
   const screen = doc.screens[0];
   const built = parseBin(
-    buildBin(toLegacy({ ...doc, screens: [{ ...screen, layers: [...screen.layers, newRing()] }] })),
+    buildBin(toLegacy({ ...doc, screens: [{ ...screen, layers: [...screen.layers, make()] }] })),
   );
   const written = built.screens[0].subs!.find((n) => n.tag === 0x81)!;
 

--- a/tests/doc-factory.test.ts
+++ b/tests/doc-factory.test.ts
@@ -37,14 +37,20 @@ test("a blank document builds into a parseable file with both of its assets", ()
 });
 
 // #37: a ring that renders in the editor but is missing on the watch. The editor wrote a shape
-// no stock file has — a 16-byte 0x5a spec under an 18-byte struct — and the watch skipped it.
-// Pinned against a stock imageless ring (Combo's battery ring) rather than against literal
-// numbers: the shape has to keep matching a file the firmware is known to draw.
+// no stock file has — a 16-byte 0x5a spec under an 18-byte struct — and a meta with no color
+// source in it (byte 7 = 0, or 4 over a zero accent slot). Pinned against a stock imageless ring
+// (Combo's battery ring) rather than against literal numbers: the bytes have to keep matching a
+// file the firmware is known to draw.
 const ringShape = (n: FaceNode) => {
   const st = n.subs!.find((s) => s.tag === TAG.struct)!;
   const spec = n.subs!.find((s) => s.tag === TAG.arc || s.tag === TAG.arcClipped)!;
 
-  return { subs: n.subs!.map((s) => s.tag), tail: st.tail, specBytes: spec.hex!.length / 2 };
+  return {
+    subs: n.subs!.map((s) => s.tag),
+    tail: st.tail,
+    specBytes: spec.hex!.length / 2,
+    color: st.meta!.slice(8, 18), // bytes 4..8: rgb / accent slot, the flag byte, the reserved one
+  };
 };
 
 test("a fresh ring is written in the same node shape as a stock imageless ring", () => {


### PR DESCRIPTION
Closes #37.

Two separate defects, both found by measuring the editor's output against the full 100-file stock corpus (79 arcs, 17 of them imageless). Neither is visible in the editor preview — both are invisible on the watch.

## 1. The node shape

| | editor | all 17 imageless rings in the corpus |
|---|---|---|
| spec node | `0x5a`, 16-byte body | `0x5b`, 17-byte body (3 bytes past what we decode) |
| struct | 18 bytes (x/y + meta) | 20 bytes (2 zero bytes past the meta) |

Confirmed on the reporter's own published face (`market/naxfvk041qj9jtc`): its battery ring is `0x81 → [0x01(18 bytes), 0x5a(16 bytes)]`, i.e. all three deviations at once. The corpus has exactly two `0x5a` nodes and both are image-backed bars on `0x80` — nothing suggests the firmware draws a `0x5a` procedurally, while imageless `0x5b` is proven 17 times over.

## 2. The color source

A ring with no art is nothing but a stroke, so its meta color bytes are not decoration. Byte 7 says where the color comes from: `1` = the rgb in bytes 4..6 (byte 8 is then `0xff`), `4` = the wearer's accent, whose **slot** is byte 4 — not a red channel.

- 206 accent-flagged widgets in the corpus, slot is `1`, `2` or `4` in every one. Never `0`.
- 17 imageless rings: 10 explicit-rgb, 7 accent. No third shape.
- The editor wrote byte 7 = `0` for a fresh ring, and the accent toggle wrote `4` over a zero slot — a widget flagged for a color that does not exist. That is exactly what the reporter's ring carries (`flags 4, rgb 0,0,0`).

## The fix

- `newRing()` mints a `0x5b` spec with the trailing bytes, the 2-byte struct tail, and accent slot 1 — byte for byte the shape of Combo's / Energetic's / Hemisphere's battery rings.
- The accent toggle picks a slot instead of leaving it at 0 (this applies to any widget, not just rings).
- The repair runs in **both** directions: `fromLegacy` fixes a bare ring as the file is opened, so an affected face is repaired in front of its author and the editor shows what will be written; `toLegacy` fixes one on the way out, so nothing else can put a ring the watch skips into a file.
- `0x5b` has nowhere to store a radius, so the editor's live one moves into `meta.w/h` on write, which is where the reader recovers it from anyway. Preview, resize and the geometry panel are unchanged.

Re-exported, the reporter's ring goes from `0x5a` `…07003700` under an 18-byte struct to `0x5b` `…0700010068` under a 20-byte one with accent slot 1 — the stock shape, with the rest of the file untouched (101 resources in, 101 out).

## Check

`tests/doc-factory.test.ts` builds a face with a ring and compares the written node (child tags, struct tail, spec body length, the meta's color bytes) against Combo's stock imageless ring — pinned to a file the firmware is known to draw, not to literal numbers. It runs over two rings: a fresh one, and one shaped the way older builds wrote them (which is what catches the repair path — an empty `rest` is not a missing one). Both fail on the old code.

Full suite: 199 passed, including the byte-for-byte corpus round trips (stock rings pass through the repair untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FfEYDPkHz92ckdJNvNTRkv