### PR TITLE
Let a layer carry more than one hand-added condition

### DIFF
--- a/src/lib/modules/editor/components/props/source.svelte
+++ b/src/lib/modules/editor/components/props/source.svelte
@@ -31,7 +31,7 @@
     $doc: doc,
     $cache: cache,
     $screen: screen,
-    conditionToggled,
+    conditionAdded,
     sourceIdSet,
     slotBindSet,
     slotMetricAdded,
@@ -289,9 +289,10 @@
       <p class="hint-xs">"show if" lines are OR-ed, "only if"/"hide if" must all hold</p>
     {/if}
   </div>
-{:else if layer.kind !== "raw"}
+{/if}
+{#if conditions.length || layer.kind !== "raw"}
   <div class="row">
-    <Button kind="secondary" onClick={() => conditionToggled(layer.id)}>
+    <Button kind="secondary" onClick={() => conditionAdded(layer.id)}>
       <Icon name="git-branch" size={14} /> add condition
     </Button>
   </div>

--- a/src/lib/modules/editor/model/edit.model.ts
+++ b/src/lib/modules/editor/model/edit.model.ts
@@ -114,7 +114,7 @@ export const moveRequested = createEvent<{
 /** ⌘] / ⌘[ — one step up or down the draw order, among the primary selection's own siblings.
  *  `moveRequested` is the tree's drag-and-drop, which needs an explicit target; this doesn't. */
 export const orderMoved = createEvent<1 | -1>();
-export const conditionToggled = createEvent<NodeId>();
+export const conditionAdded = createEvent<NodeId>();
 export const slotBindSet = createEvent<{ id: NodeId; slot: number | null; metric?: number }>();
 /** The metrics a slot offers the wearer — its own 0x5f list, which the companion app shows as a
  *  menu. Adding one needs an icon frame, so it goes through an effect; removing one is a plain
@@ -932,9 +932,9 @@ sample({
   target: committed,
 });
 
-/** Add or remove the selected layer's visibility condition. */
+/** Append a visibility condition to the selected layer (rows are removed one by one). */
 sample({
-  clock: conditionToggled,
+  clock: conditionAdded,
   source: $doc,
   filter: (doc, id) => Boolean(doc && findLayer(doc, id)),
   fn: (doc, id) => ({
@@ -942,7 +942,7 @@ sample({
       const l = findLayer(d, id)!;
 
       return patchLayer(d, id, {
-        conditions: l.conditions.length ? [] : [newCondition()],
+        conditions: [...l.conditions, newCondition()],
       } as Partial<Layer>);
     },
   }),

--- a/tests/editor-new-nodes.browser.test.ts
+++ b/tests/editor-new-nodes.browser.test.ts
@@ -168,15 +168,16 @@ test("group wraps in place and duplicate copies the whole subtree", async () => 
   expect(framesOf(copy.children[0])).toEqual(framesOf((byId(groupId) as GroupLayer).children[0]));
 });
 
-test("a visibility condition can be added and removed from the selection", async () => {
+test("visibility conditions stack up on the selection", async () => {
   await load("cond");
   const widget = plainWidget();
 
-  editorModel.conditionToggled(widget.id);
+  editorModel.conditionAdded(widget.id);
   expect(byId(widget.id).conditions).toHaveLength(1);
   // starts always-true, so adding one must not hide the widget
   expect(boxOf(widget.id)).toBeTruthy();
 
-  editorModel.conditionToggled(widget.id);
-  expect(byId(widget.id).conditions).toHaveLength(0);
+  // a second one is appended, it does not replace or clear the first
+  editorModel.conditionAdded(widget.id);
+  expect(byId(widget.id).conditions).toHaveLength(2);
 });

--- a/tests/editor-slot-bind.browser.test.ts
+++ b/tests/editor-slot-bind.browser.test.ts
@@ -67,7 +67,7 @@ test("a layer binds to one slot metric and only draws while that metric is selec
   expect(drawn(id)).toBe(true);
 
   // a real metric condition on the same layer must survive the slot binding being rewritten
-  editorModel.conditionToggled(id); // always-true steps >= 0
+  editorModel.conditionAdded(id); // always-true steps >= 0
   editorModel.slotBindSet({ id, slot: slot.index, metric: 0 });
   expect(byId(id).conditions.map((c) => c.source)).toEqual([0x19, SLOT_SEL_ID + slot.index]);
   expect(drawn(id)).toBe(true);


### PR DESCRIPTION
The "add condition" button only showed up while a layer had no conditions, and the event behind it toggled between zero and one — so a second condition could never be added from the UI, even though the format and the renderer already handle a list (official CMF faces ship layers with several).

- `conditionToggled` -> `conditionAdded`: appends `newCondition()` instead of clearing.
- The button stays visible under the conditions list; removal is still the per-row trash icon.

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012NWa1sycCMRAMq9s9LjoJL