### PR TITLE
EGR-15: Rotate теряет качество изображения

### DIFF
--- a/src/lib/modules/editor/core/document/doc.ts
+++ b/src/lib/modules/editor/core/document/doc.ts
@@ -60,6 +60,10 @@ export interface ImageAsset {
 export interface ImageCache {
   bitmap?: ImageBitmap;
   original?: ImageBitmap; // pinned source, so resize/adjust stay lossless
+  /** The pixels a rotation resamples from, and the angle they already carry — pinned on the first
+   *  turn so repeated ones don't blur, dropped wherever the art is re-baked or rescaled. See
+   *  rotateAsset. */
+  rot0?: { src: ImageBitmap; deg: number };
   accent?: ImageBitmap; // preview tint for accent-flagged assets
 }
 

--- a/src/lib/modules/editor/core/render/pixels.ts
+++ b/src/lib/modules/editor/core/render/pixels.ts
@@ -197,31 +197,50 @@ export async function invertAsset(
  *  is re-baked (like invertAsset above) and `rotate` only records the running total for the
  *  inspector. cf 4 has no alpha for the corners a non-square turn opens up, so it becomes cf 5;
  *  a JPEG resource keeps its codec and gets black corners instead.
- *  ponytail: every call resamples the current pixels, so a hundred 1° nudges blur more than one
- *  100° turn. Pin the pre-rotation bitmap in the cache if that ever shows. */
+ *  Every turn resamples the PINNED pre-rotation pixels (`cache.rot0`), never the already-turned
+ *  ones, so a hundred 1° nudges cost exactly as much quality as one 100° turn — and coming back to
+ *  the angle the pin carries restores it exactly. The pin is per session and is dropped wherever
+ *  the art is re-baked or rescaled (see assets.model). */
 export async function rotateAsset(
   a: ImageAsset,
   cache: ImageCache | undefined,
   deg: number,
-): Promise<{ asset: ImageAsset; bitmap: ImageBitmap } | null> {
-  const src = cache?.bitmap ?? (await bitmapOf({ cf: a.cf, w: a.w, h: a.h, data: a.data }));
-  const rad = (deg * Math.PI) / 180;
+): Promise<{
+  asset: ImageAsset;
+  bitmap: ImageBitmap;
+  rot0: NonNullable<ImageCache["rot0"]>;
+} | null> {
+  const pinned = cache?.rot0;
+  const rot0 = pinned ?? {
+    src: cache?.bitmap ?? (await bitmapOf({ cf: a.cf, w: a.w, h: a.h, data: a.data })),
+    deg: a.rotate ?? 0,
+  };
+  const turn = (v: number) => ((v % 360) + 360) % 360;
+  const rotate = turn((a.rotate ?? 0) + deg);
+  const ang = turn(rotate - rot0.deg); // how far the PIN turns, which isn't the delta the user drags
+  const rad = (ang * Math.PI) / 180;
   const cos = Math.abs(Math.cos(rad)),
     sin = Math.abs(Math.sin(rad));
   const size = (v: number) => Math.max(1, Math.min(2047, Math.round(v))); // 11-bit, see encodePixels
-  const w = size(a.w * cos + a.h * sin),
-    h = size(a.w * sin + a.h * cos);
-  const cf = a.cf === 4 && deg % 90 !== 0 ? 5 : a.cf;
+  const sw = rot0.src.width,
+    sh = rot0.src.height;
+  const w = size(sw * cos + sh * sin),
+    h = size(sw * sin + sh * cos);
+  const cf = a.cf === 4 && ang % 90 !== 0 ? 5 : a.cf;
   const c = new OffscreenCanvas(w, h);
   const cx = c.getContext("2d")!;
 
+  // an older pin predates the adjust dialled in since, which the turned pixels bake in (see
+  // `adjust: undefined` below); a pin taken right here IS the filtered preview bitmap already, so
+  // filtering it again would apply the adjust twice
+  if (pinned) cx.filter = filterOf(a as unknown as Resource);
   cx.translate(w / 2, h / 2);
   cx.rotate(rad);
-  cx.drawImage(src, -a.w / 2, -a.h / 2, a.w, a.h);
+  cx.drawImage(rot0.src, -sw / 2, -sh / 2, sw, sh);
   const bitmap = await createImageBitmap(c);
-  const rotate = ((((a.rotate ?? 0) + deg) % 360) + 360) % 360;
 
   return {
+    rot0,
     // the turned pixels are the ones the user was looking at, filter included — so `adjust` goes
     // back to neutral rather than claiming it could still be dialled away
     asset: {

--- a/src/lib/modules/editor/model/assets.model.ts
+++ b/src/lib/modules/editor/model/assets.model.ts
@@ -137,14 +137,18 @@ const replaceImageFx = attach({
       return {
         asset: { ...a, data, w: bitmap.width, h: bitmap.height },
         // the uploaded file is the new original — drop any pinned resize source
-        cache: { bitmap, original: undefined, accent: undefined },
+        cache: { bitmap, original: undefined, rot0: undefined, accent: undefined },
       };
     }
     const fresh = await resourceFromFile(file, a.cf);
 
     return {
       asset: { ...a, cf: fresh.cf, w: fresh.w, h: fresh.h, data: fresh.data },
-      cache: { bitmap: fresh.bitmap ?? (await bitmapOf(fresh)), original: undefined },
+      cache: {
+        bitmap: fresh.bitmap ?? (await bitmapOf(fresh)),
+        original: undefined,
+        rot0: undefined,
+      },
     };
   },
 });
@@ -161,7 +165,7 @@ const clearImageFx = attach({
 
     return {
       asset: { ...a, cf: fresh.cf, data: fresh.data },
-      cache: { bitmap: fresh.bitmap, original: undefined, accent: undefined },
+      cache: { bitmap: fresh.bitmap, original: undefined, rot0: undefined, accent: undefined },
     };
   },
 });
@@ -207,6 +211,7 @@ async function rescaleFrames(
         resizeQuality: "high",
       }),
       original: src,
+      rot0: undefined, // pinned at the old size — the next turn re-pins from these pixels
       accent: undefined, // a stale tint would keep the old size; accentFx recomputes it
     });
   }
@@ -250,7 +255,7 @@ const resizeImageFx = attach({
         assets.set(id, { ...a, cf: r.cf, w: r.w, h: r.h, data: r.data });
         // no `original`: these pixels ARE the source now, and flushAssets must not re-encode
         // them from a stale bitmap of the old size
-        cached.set(id, { bitmap, original: undefined, accent: undefined });
+        cached.set(id, { bitmap, original: undefined, rot0: undefined, accent: undefined });
       });
       glyphSpecs.set(l.id, next);
       return { assets, cache: cached, layer: l.id, patch: at ? { x: at.x, y: at.y } : {} };
@@ -363,6 +368,8 @@ const resizeGroupFx = attach({
 // Turn every frame of a widget by the same delta. Destructive, like the invert below: the file
 // format has no rotation, so the art is re-baked and the pinned original goes with it (the turned
 // pixels ARE the source from here — flushAssets must not re-encode the untouched ones over them).
+// What survives instead is `rot0`, the pre-rotation pixels: every further turn resamples those, so
+// nudging an angle a degree at a time costs no more quality than turning it once.
 const rotateImageFx = attach({
   source: { doc: $doc, cache: $cache },
   async effect({ doc, cache }, { layer, deg }: { layer: NodeId; deg: number }) {
@@ -380,14 +387,23 @@ const rotateImageFx = attach({
 
       if (!turned) continue;
       assets.set(id, turned.asset);
-      cached.set(id, { bitmap: turned.bitmap, original: undefined, accent: undefined });
+      // rot0: the pixels the NEXT turn resamples, so repeated rotations don't compound
+      cached.set(id, {
+        bitmap: turned.bitmap,
+        original: undefined,
+        rot0: turned.rot0,
+        accent: undefined,
+      });
     }
     // The bounding box grows around the centre, so the layer moves back by half of the growth and
     // the art stays where it was. A hand's pivot moves with it, which keeps x+pivot — the point it
     // rotates around at runtime — on the same pixel of the dial.
     const grown = assets.get(frames[0]);
-    const dx = grown ? Math.round((grown.w - first.w) / 2) : 0;
-    const dy = grown ? Math.round((grown.h - first.h) / 2) : 0;
+    // rounded symmetrically about zero: Math.round(-22.5) is -22 but Math.round(22.5) is 23, and
+    // that half pixel would walk the layer one step every time an angle is turned and turned back
+    const half = (v: number) => Math.sign(v) * Math.round(Math.abs(v) / 2);
+    const dx = grown ? half(grown.w - first.w) : 0;
+    const dy = grown ? half(grown.h - first.h) : 0;
     const moved = isPlaced(l) ? { x: l.x - dx, y: l.y - dy } : {};
     const patch: Partial<Layer> =
       l.kind === "hand"
@@ -492,7 +508,12 @@ const invertColorsFx = attach({
         cached.set(copy.id, { bitmap: flipped.bitmap });
       } else {
         assets.set(id, flipped.asset);
-        cached.set(id, { bitmap: flipped.bitmap, original: undefined, accent: undefined });
+        cached.set(id, {
+          bitmap: flipped.bitmap,
+          original: undefined,
+          rot0: undefined,
+          accent: undefined,
+        });
       }
     }
     return { assets, cache: cached, remap, rootIds };

--- a/tests/editor-rotate.browser.test.ts
+++ b/tests/editor-rotate.browser.test.ts
@@ -1,0 +1,108 @@
+// rotateImageRequested: the format has no angle, so a turn is a pixel edit. What must not happen
+// is a turn resampling an already-turned bitmap — that blurs the art a little more on every nudge.
+// Both tests here are about the pinned pre-rotation pixels (ImageCache.rot0) doing their job.
+import { test, expect, vi } from "vitest";
+import { findLayer } from "$lib/modules/editor/core/document/edits";
+import {
+  framesOf,
+  type ImageLayer,
+  type ImageId,
+  type NodeId,
+} from "$lib/modules/editor/core/document/doc";
+import { editorModel } from "$lib/modules/editor/model";
+import { renderDoc } from "$lib/modules/editor/core/render/render";
+import { SCREEN } from "$lib/modules/editor/core/render/screen";
+import url from "./__fixtures__/Analog__287__Simple_Dial.bin?url";
+
+const doc = () => editorModel.$doc.getState()!;
+const asset = (id: ImageId) => doc().images.get(id)!;
+const bitmapOf = (id: ImageId) => editorModel.$cache.getState().get(id)!.bitmap!;
+
+async function load(label: string) {
+  const buf = await fetch(url).then((r) => r.arrayBuffer());
+
+  await new Promise<void>((resolve) => {
+    const unwatch = editorModel.loadDone.watch(() => {
+      unwatch();
+      resolve();
+    });
+
+    editorModel.loadRequested({ buf, label });
+  });
+  editorModel.simPatched({ live: false, time: new Date("2026-01-09T10:09:30").getTime() });
+}
+
+const draw = () => {
+  const c = document.createElement("canvas");
+
+  c.width = c.height = SCREEN;
+  return renderDoc(
+    c.getContext("2d")!,
+    doc(),
+    editorModel.$store.getState(),
+    "main",
+    editorModel.$sim.getState(),
+  );
+};
+
+/** A single-frame image widget — one asset to follow, like the resize suite uses. */
+const singleFrameImage = () =>
+  draw().find((h) => h.layer.kind === "image" && framesOf(h.layer).length === 1)!;
+
+const pixels = (b: ImageBitmap) => {
+  const c = document.createElement("canvas");
+
+  c.width = b.width;
+  c.height = b.height;
+  c.getContext("2d")!.drawImage(b, 0, 0);
+  return [...c.getContext("2d")!.getImageData(0, 0, b.width, b.height).data];
+};
+
+/** Turn `layer` by `deg` and wait for the document to carry the new total. */
+async function rotate(layer: NodeId, deg: number, frame: ImageId) {
+  const want = ((((asset(frame).rotate ?? 0) + deg) % 360) + 360) % 360;
+
+  editorModel.rotateImageRequested({ layer, deg });
+  await vi.waitFor(() => expect(asset(frame).rotate).toBe(want));
+}
+
+// The reported bug: dragging the angle handle fires a turn per pointermove, and each one used to
+// resample the previous turn's pixels. Off the pinned original, twelve 5° steps have to land on
+// exactly the bytes one 60° turn produces.
+test("nudging an angle in small steps is as sharp as turning it once", async () => {
+  await load("rotate-steps-test");
+  const stepped = singleFrameImage();
+  const stepFrame = framesOf(stepped.layer)[0];
+
+  for (let i = 0; i < 12; i++) await rotate(stepped.layer.id, 5, stepFrame);
+  const many = { w: asset(stepFrame).w, h: asset(stepFrame).h, px: pixels(bitmapOf(stepFrame)) };
+
+  await load("rotate-once-test");
+  const turned = singleFrameImage();
+  const onceFrame = framesOf(turned.layer)[0];
+
+  await rotate(turned.layer.id, 60, onceFrame);
+  const once = { w: asset(onceFrame).w, h: asset(onceFrame).h, px: pixels(bitmapOf(onceFrame)) };
+
+  expect([many.w, many.h]).toEqual([once.w, once.h]);
+  expect(many.px).toEqual(once.px);
+});
+
+test("turning back to where it started restores the pixels exactly", async () => {
+  await load("rotate-return-test");
+  const hit = singleFrameImage();
+  const frame = framesOf(hit.layer)[0];
+  const before = { w: asset(frame).w, h: asset(frame).h, px: pixels(bitmapOf(frame)) };
+
+  await rotate(hit.layer.id, 37, frame);
+  expect(asset(frame).w).toBeGreaterThan(before.w); // the box grew to the leaning bbox
+  await rotate(hit.layer.id, -37, frame);
+
+  expect(asset(frame).rotate).toBe(0);
+  expect([asset(frame).w, asset(frame).h]).toEqual([before.w, before.h]);
+  expect(pixels(bitmapOf(frame))).toEqual(before.px);
+  // and the layer is back where it was, since the box shrank by exactly what it grew
+  const l0 = hit.layer as ImageLayer;
+
+  expect(findLayer(doc(), hit.layer.id)).toMatchObject({ x: l0.x, y: l0.y });
+});


### PR DESCRIPTION
Task: https://linear.app/freethinkel/issue/EGR-15/rotate-teryaet-kachestvo-izobrazheniya

Надо сделать также как и с resize сохранять оригинал изображение для сессии

---
Generated by shepherd: run `run_60e6c63655`, agent `claude`, workspace `wD`.