### PR TITLE
EGR-26: Protect material icons from google translate

### DIFF
--- a/src/lib/shared/components/icon/icon.svelte
+++ b/src/lib/shared/components/icon/icon.svelte
@@ -25,6 +25,7 @@
   style:font-variation-settings="'FILL' {fill ? 1 : 0}, 'opsz' {size}, 'wght' 300"
   style:color
   aria-hidden="true"
+  translate="no"
   {onclick}>{name}</span
 >
 

--- a/tests/ui-icon.browser.test.ts
+++ b/tests/ui-icon.browser.test.ts
@@ -21,6 +21,9 @@ test("an icon renders its ligature at the requested size", async () => {
   expect(style.fontFamily).toContain("Material Symbols Rounded");
   // fill is the FILL axis — the liked heart is the solid glyph, not a painted outline
   expect(style.fontVariationSettings).toContain('"FILL" 1');
+  // the ligature is a machine name, not prose: Google Translate turns "favorite" into a word
+  // and the glyph into garbage
+  expect(icon.getAttribute("translate")).toBe("no");
 });
 
 // A name the font doesn't know renders as its own word — many ems wide, where a real glyph is


### PR DESCRIPTION
Task: https://linear.app/freethinkel/issue/EGR-26/protect-material-icons-from-google-translate

![telegram-cloud-photo-size-2-5233734795316110160-y.jpg](https://uploads.linear.app/0cc98ae4-95cb-4c93-a47c-ec3a52e7f78a/082383b9-07c2-4c53-aed0-e3f7f069a6ff/d5a7d818-ceda-44d0-a900-375995ccf9b7)

---
Generated by shepherd: run `run_cec65c51a8`, agent `claude`, workspace `wF`.