### PR TITLE
Privacy-light analytics: self-hosted Umami

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,13 @@
+# Copy to .env and fill in. Everything here is baked into the build at `vite build` time.
+
+# PocketBase. Dev only — point it straight at the instance (no vite proxy involved).
+# Leave unset in prod: the app falls back to same-origin, which is what Caddy serves.
 VITE_PB_URL=http://127.0.0.1:8090
+
+# Self-hosted Umami. Both must be set or analytics is a no-op, which is what keeps dev
+# servers and local builds out of the dashboard — leave them unset here.
+# VITE_ANALYTICS_HOST: base URL of the instance. "/stats" when it lives behind the same
+# Caddy as PocketBase; a full origin otherwise.
+# VITE_ANALYTICS_SITE_ID: the website id Umami mints when the site is added.
+# VITE_ANALYTICS_HOST=/stats
+# VITE_ANALYTICS_SITE_ID=

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,0 +1,102 @@
+# Analytics
+
+Self-hosted [Umami](https://umami.is). No cookies, no consent banner, no third party: the
+tracker sends to our own box, and the numbers never leave it.
+
+The client side is two files — `src/lib/modules/analytics/lib/umami.ts` (the transport) and
+`model/analytics.model.ts` (the catalogue). Nothing is loaded or sent unless both
+`VITE_ANALYTICS_HOST` and `VITE_ANALYTICS_SITE_ID` are set at build time, so dev servers and
+local builds stay out of the dashboard.
+
+## Events
+
+Pageviews are the tracker's own job: it patches `history.pushState`, so SvelteKit's client-side
+navigations are counted, each with its path and referrer. `/market/<id>` therefore gives
+views-per-face for free. Everything else is a named event:
+
+| Event           | Fires when                                                | Properties     |
+| --------------- | --------------------------------------------------------- | -------------- |
+| `face_view`     | a face's showcase page finished loading                     | `id`, `name`   |
+| `editor_open`   | a document was loaded into the editor                       | `source`       |
+| `import`        | a Facer / WatchMaker / Wear OS export was read              | `format`       |
+| `watch_connect` | a watch finished pairing over Web Bluetooth                 | —              |
+| `watch_upload`  | a face was flashed onto the watch                           | —              |
+| `signup`        | an account was created through the register form            | —              |
+
+`watch_upload` is the conversion — the funnel is `pageview → face_view → editor_open →
+watch_connect → watch_upload`, and the drop between the last two is the pairing failure rate.
+
+`source` is one of `market`, `file`, `new`, `facer`, `watchmaker`, `wff`. It is deliberately a
+closed set: the editor's internal label for a dropped file is its **filename**, which is the
+user's, not ours to collect.
+
+Two known gaps, both deliberate:
+
+- **OAuth signups are not counted.** The provider call is identical for a new account and a
+  returning one, so the client can't tell them apart. Only the register form fires `signup`.
+- **The first pageview of a session has an empty title** — the tracker fires before SvelteKit
+  sets `<title>`. The URL is recorded correctly, which is what the reports group by.
+
+Adding an event means adding it to `EventName` and one `sample()` in `analytics.model.ts`. The
+model subscribes to events the feature models already fire rather than being called from them,
+so `tests/analytics-events.browser.test.ts` is what catches a name or payload drifting.
+
+## Deploying it (backend repo)
+
+Umami is a Next.js app plus PostgreSQL. It goes next to PocketBase in `fmc_pocketbase`'s
+`docker-compose.yml`, not exposed directly — Caddy fronts it on the same domain, which also
+keeps the tracker on our own origin where ad-blocker heuristics leave it alone.
+
+```yaml
+umami:
+  image: ghcr.io/umami-software/umami:postgresql-latest
+  container_name: umami
+  restart: unless-stopped
+  environment:
+    DATABASE_URL: postgresql://umami:${UMAMI_DB_PASSWORD}@umami-db:5432/umami
+    DATABASE_TYPE: postgresql
+    APP_SECRET: ${UMAMI_APP_SECRET} # any long random string; rotating it logs everyone out
+    BASE_PATH: /stats # must match the Caddy path below
+  depends_on: [umami-db]
+
+umami-db:
+  image: postgres:16-alpine
+  container_name: umami-db
+  restart: unless-stopped
+  environment:
+    POSTGRES_DB: umami
+    POSTGRES_USER: umami
+    POSTGRES_PASSWORD: ${UMAMI_DB_PASSWORD}
+  volumes:
+    - umami_db:/var/lib/postgresql/data
+```
+
+…with `umami_db:` added under the existing `volumes:` block, and in the `Caddyfile`, **above**
+the catch-all `handle` that serves the SPA:
+
+```caddyfile
+handle /stats/* {
+	reverse_proxy umami:3000
+}
+```
+
+Then, once: log in at `https://<domain>/stats` (default `admin` / `umami` — change it
+immediately), add the site, and copy the website id it mints. Set both vars in the frontend's
+`.env` before `make deploy`:
+
+```sh
+VITE_ANALYTICS_HOST=/stats
+VITE_ANALYTICS_SITE_ID=<the id from the dashboard>
+```
+
+To keep your own visits out of the numbers, run `localStorage.setItem('umami.disabled', 1)` in
+the browser console once, per browser.
+
+## Cost
+
+The tracker is 4.7 KB over the wire, 2.3 KB gzipped, loaded `defer` after the app — measured
+against `cloud.umami.is/script.js`, not quoted from the docs. On the editor route that is a
+rounding error next to the canvas bundle; on the marketplace it is the smallest thing on the
+page. Server-side it is one Node container plus a Postgres, roughly 400–600 MB of RAM on a box
+that today runs a 31 MB Go binary — the real cost of this choice, and the reason Plausible CE
+(which needs ClickHouse, 2–4 GB) was not the pick.

--- a/src/lib/modules/analytics/lib/umami.ts
+++ b/src/lib/modules/analytics/lib/umami.ts
@@ -1,0 +1,40 @@
+// Umami's tracker script: cookie-free, no consent banner, 4.7 KB over the wire / 2.3 KB gzipped
+// (measured against cloud.umami.is/script.js). It counts pageviews itself — it patches
+// history.pushState/replaceState, so SvelteKit's client-side navigations are covered without any
+// code here — and everything else arrives through window.umami.track(name, props).
+//
+// Two env vars turn it on; without both, every call below is a no-op, so dev servers, preview
+// builds and anyone running the app locally never reach the founder's dashboard:
+//   VITE_ANALYTICS_HOST     base URL of the Umami instance — "/stats" when it sits behind the
+//                           same Caddy as PocketBase, or "https://stats.example.com"
+//   VITE_ANALYTICS_SITE_ID  the website id Umami mints when the site is added
+//
+// The tracker defaults its ingest endpoint to Umami's own cloud gateway, so data-host-url is
+// not optional for a self-hosted instance — it is what keeps our numbers on our box.
+const HOST: string | undefined = import.meta.env.VITE_ANALYTICS_HOST;
+const SITE: string | undefined = import.meta.env.VITE_ANALYTICS_SITE_ID;
+
+interface Umami {
+  track(name: string, props?: Record<string, string | number | boolean>): void;
+}
+
+export const enabled = Boolean(HOST && SITE);
+
+/** Append the tracker once. Deferred, so it never competes with the editor's first paint. */
+export const loadTracker = () => {
+  if (!enabled || document.querySelector("script[data-website-id]")) return;
+
+  const el = document.createElement("script");
+
+  el.defer = true;
+  el.src = `${HOST!.replace(/\/$/, "")}/script.js`;
+  el.dataset.websiteId = SITE!;
+  el.dataset.hostUrl = HOST!;
+  document.head.append(el);
+};
+
+// ponytail: an event fired before the deferred script finishes loading is dropped rather than
+// queued. Every event we send follows a click that cannot plausibly beat it. Upgrade path if one
+// ever can: buffer into an array here and flush it from the script's onload.
+export const sendEvent = (name: string, props?: Record<string, string | number | boolean>) =>
+  (window as { umami?: Umami }).umami?.track(name, props);

--- a/src/lib/modules/analytics/model/analytics.model.ts
+++ b/src/lib/modules/analytics/model/analytics.model.ts
@@ -1,0 +1,98 @@
+// What the launch is measured by, in one place.
+//
+//   face_view      a face's showcase page was opened            { id, name }
+//   editor_open    a document was loaded into the editor        { source }
+//   import         a Facer/WatchMaker/Wear OS export was read   { format }
+//   watch_connect  a watch paired over Web Bluetooth
+//   watch_upload   a face was flashed onto the watch — the conversion everything else leads to
+//   signup         a new account was created through the register form
+//
+// Pageviews (path + referrer) are the tracker script's own job, see ../lib/umami.
+//
+// Every moment above already has an event in the model that owns it, so this file subscribes to
+// those rather than scattering track() calls through the feature models: the entire catalogue of
+// what FMC reports about its users stays readable on one screen, which is the point of an
+// analytics layer you can defend to a privacy-minded audience.
+import { createEffect, createEvent, sample } from "effector";
+import { authModel } from "$lib/modules/auth/model";
+import { bleModel } from "$lib/modules/device/model";
+import { editorModel } from "$lib/modules/editor/model";
+import { marketModel } from "$lib/modules/market/model";
+import { loadTracker, sendEvent } from "../lib/umami";
+
+export type EventName =
+  | "face_view"
+  | "editor_open"
+  | "import"
+  | "watch_connect"
+  | "watch_upload"
+  | "signup";
+
+// ---- events ----
+/** Fired once from the root layout — nothing is loaded or sent before it. */
+export const started = createEvent();
+
+// ---- effects ----
+const initFx = createEffect(loadTracker);
+const trackFx = createEffect(
+  ({ name, props }: { name: EventName; props?: Record<string, string> }) => sendEvent(name, props),
+);
+
+// ---- business logic ----
+sample({
+  clock: started,
+  target: initFx,
+});
+
+// the showcase page nulls the store while the next face loads, so only a record is a view
+sample({
+  clock: marketModel.$watchface.updates,
+  filter: Boolean,
+  fn: (wf) => ({ name: "face_view" as const, props: { id: wf.id, name: String(wf.name ?? "") } }),
+  target: trackFx,
+});
+
+// loadDone's label is a filename for a dropped .bin and the face's own name for a marketplace
+// open — free-form either way. Fold it into a bounded set: a dashboard breakdown of arbitrary
+// filenames is noise, and the filenames are the user's, not ours to collect.
+const IMPORTERS: readonly string[] = ["facer", "watchmaker", "wff"];
+const sourceOf = (key: string | null, label: string) =>
+  key ? "market" : IMPORTERS.includes(label) || label === "new" ? label : "file";
+
+sample({
+  clock: editorModel.loadDone,
+  source: editorModel.$faceKey,
+  fn: (key, { label }) => ({
+    name: "editor_open" as const,
+    props: { source: sourceOf(key, label) },
+  }),
+  target: trackFx,
+});
+sample({
+  clock: editorModel.loadDone,
+  filter: ({ label }) => IMPORTERS.includes(label),
+  fn: ({ label }) => ({ name: "import" as const, props: { format: label } }),
+  target: trackFx,
+});
+
+// $bleInfo is reset to null on every connect attempt and on disconnect — a record means the
+// handshake got all the way through
+sample({
+  clock: bleModel.$bleInfo.updates,
+  filter: Boolean,
+  fn: () => ({ name: "watch_connect" as const }),
+  target: trackFx,
+});
+sample({
+  clock: bleModel.flashDone,
+  fn: () => ({ name: "watch_upload" as const }),
+  target: trackFx,
+});
+
+// OAuth can't tell a first login from a returning one — the provider call is the same either
+// way — so this counts registrations through the form only. See docs/analytics.md.
+sample({
+  clock: authModel.registered,
+  fn: () => ({ name: "signup" as const }),
+  target: trackFx,
+});

--- a/src/lib/modules/analytics/model/index.ts
+++ b/src/lib/modules/analytics/model/index.ts
@@ -1,0 +1,1 @@
+export * as analyticsModel from "./analytics.model";

--- a/src/lib/modules/auth/model/auth.model.ts
+++ b/src/lib/modules/auth/model/auth.model.ts
@@ -28,6 +28,10 @@ export const registerRequested = createEvent<{
   name?: string;
 }>();
 export const oauthRequested = createEvent<string>();
+// cross-module signal (analytics counts signups) — exposed as an event, not the effect itself,
+// so other models react without touching authApi. OAuth has no equivalent: the provider call is
+// the same for a new account and a returning one.
+export const registered = createEvent();
 
 // business logic
 pb.authStore.onChange(() => userChanged(pb.authStore.record));
@@ -66,6 +70,12 @@ sample({
 sample({
   clock: registerRequested,
   target: authApi.registerFx,
+});
+
+sample({
+  clock: authApi.registerFx.done,
+  fn: () => undefined,
+  target: registered,
 });
 
 sample({

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,5 +1,9 @@
 // beacio bootstrap: bridges navigator.bluetooth to the Safari extension on iOS, no-op in Chrome
 import "@beacio/core/auto";
+import { analyticsModel } from "$lib/modules/analytics/model";
+
+// self-hosted, cookie-free analytics — a no-op build unless VITE_ANALYTICS_* are set
+analyticsModel.started();
 
 export const ssr = false;
 export const prerender = false;

--- a/tests/analytics-events.browser.test.ts
+++ b/tests/analytics-events.browser.test.ts
@@ -1,0 +1,61 @@
+// The analytics model reads the app's existing event graph rather than being called from it, so
+// nothing in the feature models fails when a name or a payload here drifts. This test is what
+// notices: it drives the same events the app fires and asserts on what reaches the tracker.
+import { test, expect, beforeEach } from "vitest";
+import type { Doc } from "$lib/modules/editor/core/document/doc";
+import { authModel } from "$lib/modules/auth/model";
+import { bleModel } from "$lib/modules/device/model";
+import { editorModel } from "$lib/modules/editor/model";
+import "$lib/modules/analytics/model";
+
+const doc = {} as Doc; // the payload the model never looks at
+let sent: [string, unknown][] = [];
+
+beforeEach(() => {
+  sent = [];
+  // stand in for the tracker script, which a test build never loads
+  (window as { umami?: { track: (n: string, p?: unknown) => void } }).umami = {
+    track: (name, props) => sent.push([name, props]),
+  };
+  editorModel.faceKeySet(null);
+});
+
+test("a marketplace open is editor_open{market}, not an import", () => {
+  editorModel.faceKeySet("wf1");
+  editorModel.loadDone({ doc, label: "Nothing Dots" }); // label is the face's own name
+
+  expect(sent).toEqual([["editor_open", { source: "market" }]]);
+});
+
+test("a dropped file keeps its name out of the payload", () => {
+  editorModel.loadDone({ doc, label: "my holiday photos.bin" });
+
+  expect(sent).toEqual([["editor_open", { source: "file" }]]);
+});
+
+test("an import reports both the open and the format", () => {
+  editorModel.loadDone({ doc, label: "facer" });
+
+  expect(sent).toEqual([
+    ["editor_open", { source: "facer" }],
+    ["import", { format: "facer" }],
+  ]);
+});
+
+test("a blank face is neither a file nor an import", () => {
+  editorModel.loadDone({ doc, label: "new" });
+
+  expect(sent).toEqual([["editor_open", { source: "new" }]]);
+});
+
+test("a successful flash is the conversion event", () => {
+  bleModel.flashDone();
+
+  expect(sent).toEqual([["watch_upload", undefined]]);
+});
+
+test("a registration is a signup", () => {
+  authModel.registered();
+
+  expect(sent).toEqual([["signup", undefined]]);
+});


### PR DESCRIPTION
Instruments the site so the launch produces numbers instead of vibes. FMC-4.

## Why Umami

Compared on what it costs to run next to PocketBase, what it weighs on a page that already
loads a canvas editor, and what it can actually answer:

| | Self-host cost | Tracker | Events with properties |
| --- | --- | --- | --- |
| **Umami** | Node + Postgres, ~400-600 MB | 2.3 KB gz | yes, named + typed props |
| Plausible CE | Postgres **+ ClickHouse**, [2-4 GB RAM](https://github.com/plausible/community-edition/) | ~1 KB gz | yes |
| GoatCounter | one Go binary + SQLite, ~50 MB | ~1 KB gz | **no** - ["no real way to record the path with the event"](https://www.goatcounter.com/help/events) |
| Fathom Lite | one Go binary + SQLite | small | feature-frozen upstream |

GoatCounter is the cheapest to run and the closest in spirit to a PocketBase box, but its
events carry no properties, so `import{format}` and `editor_open{source}` would have to be
encoded into event names. Plausible CE has the properties and needs ClickHouse to get them -
2-4 GB on a VPS whose entire backend today is a 31 MB Go binary. Umami is the cheapest option
that answers the questions the monetization work depends on. Reasoning and the numbers behind
it: `docs/analytics.md`.

## Weight

The tracker is **4.7 KB over the wire / 2.3 KB gzipped**, measured against
`cloud.umami.is/script.js`, loaded `defer` after the app. Zero cookies - verified, see below.
No new npm dependency: it is one `<script>` tag appended at runtime.

## Events

`watch_upload` is the conversion. Full table in `docs/analytics.md`.

| Event | Fires when | Properties |
| --- | --- | --- |
| pageview | any navigation, SPA included | path, referrer |
| `face_view` | a showcase page finished loading | `id`, `name` |
| `editor_open` | a document loaded into the editor | `source` |
| `import` | a Facer/WatchMaker/Wear OS export was read | `format` |
| `watch_connect` | a watch paired over Web Bluetooth | - |
| `watch_upload` | **a face was flashed onto the watch** | - |
| `signup` | an account was created through the register form | - |

## Shape

`modules/analytics/` subscribes to events the feature models already fire rather than being
called from them, so the entire catalogue of what FMC reports about its users reads on one
screen - which is the thing you want to be able to point at with this audience. The only
change to an existing model is a `registered` event in `auth.model`, exposed for the same
reason `ble.model` already exposes `flashDone`.

The editor's label for a loaded document is a **filename** for a dropped `.bin`. It is folded
into a closed set (`market | file | new | facer | watchmaker | wff`) before it is sent.

## Verify

- `tests/analytics-events.browser.test.ts` - 6 tests, drives the same events the app fires and
  asserts on what reaches the tracker, including that a filename never leaves the browser.
- End-to-end against the real Umami tracker served from a local ingest stub: script tag
  (`src`/`data-website-id`/`data-host-url`/`defer`) correct, **0 cookies** after load, initial
  pageview carried the external referrer, an SPA `pushState` to `/market/<id>` produced a
  second pageview with the full path, and `watch_upload` reached `/api/send`.
- `pnpm check` 0 errors, `pnpm lint` clean, `pnpm build` clean.

## Not done here

Nothing is deployed and nothing is on. The build is a no-op until `VITE_ANALYTICS_HOST` and
`VITE_ANALYTICS_SITE_ID` are set. The compose service, the Caddy `handle /stats/*` block and
the first login are the founder's to apply - snippets ready to paste in `docs/analytics.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)