### PR TITLE
Record which watch model connected and uploaded

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -14,14 +14,15 @@ Pageviews are the tracker's own job: it patches `history.pushState`, so SvelteKi
 navigations are counted, each with its path and referrer. `/market/<id>` therefore gives
 views-per-face for free. Everything else is a named event:
 
-| Event           | Fires when                                                | Properties     |
-| --------------- | --------------------------------------------------------- | -------------- |
-| `face_view`     | a face's showcase page finished loading                     | `id`, `name`   |
-| `editor_open`   | a document was loaded into the editor                       | `source`       |
-| `import`        | a Facer / WatchMaker / Wear OS export was read              | `format`       |
-| `watch_connect` | a watch finished pairing over Web Bluetooth                 | —              |
-| `watch_upload`  | a face was flashed onto the watch                           | —              |
-| `signup`        | an account was created through the register form            | —              |
+| Event                 | Fires when                                       | Properties         |
+| --------------------- | ------------------------------------------------ | ------------------ |
+| `face_view`           | a face's showcase page finished loading          | `id`, `name`       |
+| `editor_open`         | a document was loaded into the editor            | `source`           |
+| `import`              | a Facer / WatchMaker / Wear OS export was read   | `format`           |
+| `watch_connect`       | a watch finished pairing over Web Bluetooth      | `device`           |
+| `watch_upload`        | a face was flashed onto the watch                | `device`           |
+| `watch_upload_failed` | a flash was started and did not finish           | `device`, `reason` |
+| `signup`              | an account was created through the register form | —                  |
 
 `watch_upload` is the conversion — the funnel is `pageview → face_view → editor_open →
 watch_connect → watch_upload`, and the drop between the last two is the pairing failure rate.
@@ -29,6 +30,29 @@ watch_connect → watch_upload`, and the drop between the last two is the pairin
 `source` is one of `market`, `file`, `new`, `facer`, `watchmaker`, `wff`. It is deliberately a
 closed set: the editor's internal label for a dropped file is its **filename**, which is the
 user's, not ours to collect.
+
+`reason` is the same kind of closed set, for the same reason — the raw failure messages carry
+byte dumps and slot ids. It is one of `bad_file`, `rejected` (the watch said no), `stalled`
+(timed out mid-transfer), `disconnected`, `error` (anything else). A full watch is not counted:
+that path opens the slot dialog and the user tries again.
+
+### `device`, and why it is collected
+
+`device` is the watch model: `CMF Watch Pro 2`, `CMF Watch 3 Pro`, `CMF Watch Pro 3`, or
+`other`. This is a widening of what FMC collects — it is data about the user's hardware, not
+about the site — so it is written down here rather than added quietly.
+
+What we get from the watch is its advertised BLE name, e.g. `CMF Watch Pro 2-1A2B`. That tail
+identifies the individual unit, so it never leaves the browser: the name is matched against the
+list of models above and only the match is sent. An unrecognised watch is `other` — no
+free-form string reaches the dashboard, exactly like `source`.
+
+It is here because FMC is developed against one physical watch. Without the model on these
+events, a Pro 3 that pairs and then fails to flash is invisible: it looks like a Pro 2 user who
+changed their mind. With it, `watch_connect{device} → watch_upload{device}` is a per-model
+funnel, and every Pro 3 owner who visits reports on hardware nobody here can test. Both Pro 3
+spellings are listed because that model's advertised string is unverified; if `other` starts
+filling up, that is the thing to fix.
 
 Two known gaps, both deliberate:
 

--- a/src/lib/modules/analytics/model/analytics.model.ts
+++ b/src/lib/modules/analytics/model/analytics.model.ts
@@ -1,11 +1,12 @@
 // What the launch is measured by, in one place.
 //
-//   face_view      a face's showcase page was opened            { id, name }
-//   editor_open    a document was loaded into the editor        { source }
-//   import         a Facer/WatchMaker/Wear OS export was read   { format }
-//   watch_connect  a watch paired over Web Bluetooth
-//   watch_upload   a face was flashed onto the watch — the conversion everything else leads to
-//   signup         a new account was created through the register form
+//   face_view           a face's showcase page was opened            { id, name }
+//   editor_open         a document was loaded into the editor        { source }
+//   import              a Facer/WatchMaker/Wear OS export was read   { format }
+//   watch_connect       a watch paired over Web Bluetooth            { device }
+//   watch_upload        a face was flashed — the conversion everything else leads to { device }
+//   watch_upload_failed a flash was started and did not finish       { device, reason }
+//   signup              a new account was created through the register form
 //
 // Pageviews (path + referrer) are the tracker script's own job, see ../lib/umami.
 //
@@ -26,6 +27,7 @@ export type EventName =
   | "import"
   | "watch_connect"
   | "watch_upload"
+  | "watch_upload_failed"
   | "signup";
 
 // ---- events ----
@@ -75,17 +77,46 @@ sample({
   target: trackFx,
 });
 
-// $bleInfo is reset to null on every connect attempt and on disconnect — a record means the
-// handshake got all the way through
+// The watch's advertised name ("CMF Watch Pro 2-1A2B") is the only model id the protocol gives
+// us, and it is data about the user's hardware — so, like `source` above, it is folded to a
+// closed set before it leaves the browser: the serial-ish tail never goes anywhere. Everything
+// unrecognised is `other`, which doubles as "a watch we don't support yet turned up".
+// ponytail: the Pro 3's advertised string is unverified — nobody here owns one — so both
+// spellings Nothing uses for it are listed. If `other` starts filling up, that's the one to fix.
+const MODELS = ["CMF Watch Pro 2", "CMF Watch 3 Pro", "CMF Watch Pro 3"];
+const deviceOf = (name: string | null | undefined) => {
+  const advertised = name?.toLowerCase() ?? "";
+
+  return MODELS.find((m) => advertised.includes(m.toLowerCase())) ?? "other";
+};
+
+// A flash failure message carries byte dumps and slot ids; only the shape of the failure is
+// reportable — and the shape is the whole point, because "the Pro 3 connects and then gets
+// rejected by its own firmware" is invisible in a funnel drop.
+const REASONS: [RegExp, string][] = [
+  [/not a watchface|trailer name mismatch|larger than/i, "bad_file"],
+  [/rejected the upload|did not accept the file|refused/i, "rejected"],
+  [/stalled|timeout/i, "stalled"],
+  [/disconnect/i, "disconnected"],
+];
+const reasonOf = (e: Error) => REASONS.find(([re]) => re.test(e.message))?.[1] ?? "error";
+
 sample({
-  clock: bleModel.$bleInfo.updates,
-  filter: Boolean,
-  fn: () => ({ name: "watch_connect" as const }),
+  clock: bleModel.connected,
+  fn: (watch) => ({ name: "watch_connect" as const, props: { device: deviceOf(watch.name) } }),
   target: trackFx,
 });
 sample({
   clock: bleModel.flashDone,
-  fn: () => ({ name: "watch_upload" as const }),
+  fn: (watch) => ({ name: "watch_upload" as const, props: { device: deviceOf(watch?.name) } }),
+  target: trackFx,
+});
+sample({
+  clock: bleModel.flashFailed,
+  fn: ({ watch, error }) => ({
+    name: "watch_upload_failed" as const,
+    props: { device: deviceOf(watch?.name), reason: reasonOf(error) },
+  }),
   target: trackFx,
 });
 

--- a/src/lib/modules/device/model/ble.model.ts
+++ b/src/lib/modules/device/model/ble.model.ts
@@ -38,9 +38,13 @@ export const connectRequested = createEvent();
 export const flashRequested = createEvent<FlashPayload>();
 export const slotPicked = createEvent<number>();
 export const slotDialogClosed = createEvent();
-// cross-module signal (market.model bumps the download counter on a successful flash) —
-// exposed as an event, not the effect itself, so other models react without touching flashFx
-export const flashDone = createEvent();
+// cross-module signals (market.model bumps the download counter on a successful flash,
+// analytics.model counts both) — exposed as events, not the effects themselves, so other models
+// react without touching connectFx/flashFx. They carry the connected watch because who it was is
+// part of what happened, and $bleInfo is already gone by the time a disconnect is handled.
+export const connected = createEvent<WatchInfo>();
+export const flashDone = createEvent<WatchInfo | null>();
+export const flashFailed = createEvent<{ watch: WatchInfo | null; error: Error }>();
 export const forgetRequested = createEvent();
 
 // ---- effects ----
@@ -101,7 +105,7 @@ sample({
 
 sample({
   clock: connectFx.doneData,
-  target: $bleInfo,
+  target: [$bleInfo, connected],
 });
 reset({ clock: [connectFx, disconnected], target: $bleInfo });
 
@@ -151,8 +155,16 @@ reset({ clock: [slotDialogClosed, flashFx.done, disconnected], target: $pendingB
 
 sample({
   clock: flashFx.done,
-  fn: () => undefined,
+  source: $bleInfo,
   target: flashDone,
+});
+sample({
+  clock: flashFx.failData,
+  source: $bleInfo,
+  // a full watch isn't a failure either — the slot dialog above turns it into another attempt
+  filter: (_watch, e) => !(e instanceof NoFreeSlotError),
+  fn: (watch, error) => ({ watch, error }),
+  target: flashFailed,
 });
 
 sample({

--- a/tests/analytics-events.browser.test.ts
+++ b/tests/analytics-events.browser.test.ts
@@ -3,12 +3,20 @@
 // notices: it drives the same events the app fires and asserts on what reaches the tracker.
 import { test, expect, beforeEach } from "vitest";
 import type { Doc } from "$lib/modules/editor/core/document/doc";
+import type { WatchInfo } from "$lib/modules/device/lib/ble";
 import { authModel } from "$lib/modules/auth/model";
 import { bleModel } from "$lib/modules/device/model";
 import { editorModel } from "$lib/modules/editor/model";
 import "$lib/modules/analytics/model";
 
 const doc = {} as Doc; // the payload the model never looks at
+// only the advertised name is read; the tail after the model is the unit, not the model
+const watch = (name: string | null): WatchInfo => ({
+  name,
+  battery: null,
+  firmware: null,
+  serial: null,
+});
 let sent: [string, unknown][] = [];
 
 beforeEach(() => {
@@ -48,10 +56,37 @@ test("a blank face is neither a file nor an import", () => {
   expect(sent).toEqual([["editor_open", { source: "new" }]]);
 });
 
-test("a successful flash is the conversion event", () => {
-  bleModel.flashDone();
+test("a successful flash is the conversion event, and names the watch model", () => {
+  bleModel.flashDone(watch("CMF Watch Pro 2-1A2B"));
 
-  expect(sent).toEqual([["watch_upload", undefined]]);
+  expect(sent).toEqual([["watch_upload", { device: "CMF Watch Pro 2" }]]);
+});
+
+test("a connect reports the model without the unit's own tail", () => {
+  bleModel.connected(watch("CMF Watch 3 Pro-9F0C"));
+
+  expect(sent).toEqual([["watch_connect", { device: "CMF Watch 3 Pro" }]]);
+});
+
+test("an unknown watch is other, not its advertised name", () => {
+  bleModel.connected(watch("Someone's Pixel Watch"));
+  bleModel.flashDone(watch(null));
+
+  expect(sent).toEqual([
+    ["watch_connect", { device: "other" }],
+    ["watch_upload", { device: "other" }],
+  ]);
+});
+
+test("a failed flash reports the shape of the failure, not the message", () => {
+  bleModel.flashFailed({
+    watch: watch("CMF Watch Pro 2-1A2B"),
+    error: new Error("watch rejected the upload (init1: 0a00)"),
+  });
+
+  expect(sent).toEqual([
+    ["watch_upload_failed", { device: "CMF Watch Pro 2", reason: "rejected" }],
+  ]);
 });
 
 test("a registration is a signup", () => {


### PR DESCRIPTION
Stacked on #55 — the analytics module it extends isn't on `main` yet, so the base is
`fmc-4-privacy-light-analytics`. Retarget to `main` once #55 merges.

## What changed

`watch_connect` and `watch_upload` now carry a `device` property, and a flash that starts and
does not finish fires a new `watch_upload_failed` with `device` and `reason`.

FMC is developed against one physical Pro 2. Today the funnel can say "a watch connected and
then didn't upload", but not which watch — so a Pro 3 that pairs and is then rejected by its
own firmware looks exactly like a Pro 2 user who changed their mind. With `device`, the
connect → upload funnel splits per model and every Pro 3 owner who visits reports on hardware
nobody here can test.

## On collection — please read this bit

This widens what FMC collects: the watch model is data about the user's hardware. It is
handled the way `source` already is, and `docs/analytics.md` now has a section stating it
outright rather than letting it in quietly.

- The advertised BLE name is `CMF Watch Pro 2-1A2B`. That tail identifies the individual unit,
  so it never leaves the browser — the name is matched against a literal list of models and
  only the match is sent. Anything unrecognised is `other`.
- `reason` is likewise closed (`bad_file`, `rejected`, `stalled`, `disconnected`, `error`).
  The raw messages carry byte dumps and slot ids; only the shape of the failure goes out.
- A full watch is not a failure — that path opens the slot dialog and the user retries — so it
  stays out of `watch_upload_failed`, as it already stays out of the status line.

## Model changes

`ble.model` grows two exported events so analytics can subscribe to the moments instead of
inferring them: `connected` (replacing "a non-null `$bleInfo` update means the handshake
finished") and `flashFailed`. `flashDone` now carries the watch it flashed; both of its
existing consumers in `market.model` ignore the clock payload, so they are untouched.

## Verify

- `npx vitest run tests/analytics-events.browser.test.ts` — 9 pass, 4 of them new: the model
  fold, the unit tail being stripped, an unknown watch becoming `other`, and a failure
  reporting its shape and not its message.
- `svelte-check` clean, `oxlint`/`oxfmt` clean.
- No new dependencies. Inert until the Umami container is deployed (compose/Caddy step in
  `docs/analytics.md`, still yours).

Two things I could not verify and would flag: the Pro 3's advertised name string (no unit
here — both spellings Nothing uses are listed, and `other` filling up is the signal that it's
wrong), and the failure-message patterns behind `reason`, which are read off the `throw` sites
in `ble.ts` rather than observed on a real failed flash.

Closes FMC-10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)