### PR TITLE
Add a device field to a watchface, with a badge and a marketplace filter

### DIFF
--- a/src/lib/modules/editor/components/PublishDialog.svelte
+++ b/src/lib/modules/editor/components/PublishDialog.svelte
@@ -3,9 +3,11 @@
   import { Button } from "$lib/shared/components/button";
   import { Field } from "$lib/shared/components/field";
   import { Input } from "$lib/shared/components/input";
+  import { Select } from "$lib/shared/components/select";
   import { Textarea } from "$lib/shared/components/textarea";
   import { authModel } from "$lib/modules/auth/model";
   import { marketModel } from "$lib/modules/market/model";
+  import { DEVICES } from "$lib/modules/market/lib/devices";
   import { editorModel } from "../model";
 
   const { $user: user } = authModel;
@@ -13,15 +15,28 @@
     publishRequested,
     $savePending: busy,
     $publishDialogOpen: open,
+    $openedWf: openedWf,
     publishDialogClosed,
   } = marketModel;
   const { $doc: doc, buildCurrentBin, previewBlob } = editorModel;
 
   let name = $state("");
   let description = $state("");
+  // Deliberately not defaulted to the Watch Pro 2: the editor renders both watches identically
+  // (same 466x466 panel), so guessing here would re-create exactly the mislabelling this field
+  // exists to end. Publish stays disabled until the creator says which watch they drew for.
+  let device = $state("");
+  const DEVICE_OPTIONS = [
+    { value: "", label: "Select a watch…" },
+    ...DEVICES.map((d) => ({ value: d.value, label: d.label })),
+  ];
 
   $effect(() => {
-    if ($open) name = $doc?.name || "Custom";
+    if ($open) {
+      name = $doc?.name || "Custom";
+      // re-publishing an own face keeps the device it already carries
+      device = typeof $openedWf?.device === "string" ? $openedWf.device : "";
+    }
   });
 
   async function publish() {
@@ -29,6 +44,7 @@
     publishRequested({
       name,
       description,
+      device,
       ownerId: $user.id,
       published: true,
       bin: await buildCurrentBin(),
@@ -43,13 +59,16 @@
     <Field label="Name">
       <Input bind:value={name} maxlength={100} />
     </Field>
+    <Field label="Watch" hint="Sets the badge on your card and which device filter finds it.">
+      <Select bind:value={device} options={DEVICE_OPTIONS} />
+    </Field>
     <Field label="Description">
       <Textarea bind:value={description} rows={3} maxlength={1000} />
     </Field>
   </div>
   <div class="footer">
     <Button kind="ghost" onClick={() => publishDialogClosed()}>Cancel</Button>
-    <Button kind="primary" disabled={$busy || !name.trim()} onClick={publish}>
+    <Button kind="primary" disabled={$busy || !name.trim() || !device} onClick={publish}>
       {$busy ? "Uploading…" : "Publish"}
     </Button>
   </div>

--- a/src/lib/modules/market/components/watchface-card/watchface-card.svelte
+++ b/src/lib/modules/market/components/watchface-card/watchface-card.svelte
@@ -7,6 +7,7 @@
   import { fileUrl, downloadUrl } from "$lib/shared/api";
   import type { RecordModel } from "pocketbase";
   import { Avatar } from "$lib/shared/components/avatar";
+  import { deviceLabel } from "../../lib/devices";
 
   interface Props {
     wf: RecordModel;
@@ -46,6 +47,9 @@
   const authorName = $derived(wf.expand?.owner?.name || "—");
 
   const avatar = $derived(wf.expand?.owner ? fileUrl(wf.expand?.owner, "avatar") : undefined);
+
+  // "" for a face that doesn't claim a device — most of the marketplace predates the field
+  const device = $derived(deviceLabel(wf.device));
 </script>
 
 <Card onClick={onOpen}>
@@ -86,6 +90,9 @@
         <Badge>{wf.published ? "Published" : "Draft"}</Badge>
       {:else if wf.type}
         <Badge>{wf.type}</Badge>
+      {/if}
+      {#if device}
+        <Badge quiet>{device}</Badge>
       {/if}
 
       {#if manage || canRemove}

--- a/src/lib/modules/market/lib/devices.ts
+++ b/src/lib/modules/market/lib/devices.ts
@@ -1,0 +1,45 @@
+// Which watch a published face was made for. The `device` select on the PocketBase
+// `watchfaces` collection — the values here are the schema's values, so they change together
+// with the migration in fmc_pocketbase that defines them.
+//
+// This is catalog metadata, not device geometry: both watches drive a 466x466 panel and share
+// the same .bin layout, so nothing in the file says which one a face was drawn for. Only the
+// creator knows, which is why they used to type it into the name.
+
+export interface Device {
+  value: string;
+  /** Full product name — the dropdown row and the showcase page. */
+  label: string;
+  /** What the card badge and the closed filter show, where "CMF" is already implied. */
+  short: string;
+}
+
+export const DEVICES: Device[] = [
+  { value: "watch_pro_2", label: "CMF Watch Pro 2", short: "Watch Pro 2" },
+  { value: "watch_3_pro", label: "CMF Watch 3 Pro", short: "Watch 3 Pro" },
+  { value: "watch_pro", label: "CMF Watch Pro", short: "Watch Pro" },
+];
+
+/**
+ * The watch a face is assumed to be for when it doesn't say. FMC only ever targeted the
+ * Watch Pro 2 — the editor, the BLE flashing path and the seeded catalog are all its — so
+ * everything published before this field existed was authored there unless the creator wrote
+ * otherwise in the name.
+ */
+export const DEFAULT_DEVICE = "watch_pro_2";
+
+/** Badge/showcase text for a record's device, or "" when it doesn't claim one. */
+export const deviceLabel = (device: unknown): string =>
+  DEVICES.find((d) => d.value === device)?.short ?? "";
+
+/**
+ * Does a face whose record says `wfDevice` belong on the shelf for `device`? An empty `device`
+ * is the whole marketplace.
+ *
+ * ponytail: an untagged face falls under DEFAULT_DEVICE rather than dropping out of every
+ * shelf, because most of the marketplace predates the field and a filter that hid all of it
+ * would be useless on day one. Upgrade path: once the untagged backlog is claimed by its
+ * creators, drop the fallback arm and let unset mean "unknown".
+ */
+export const matchesDevice = (wfDevice: unknown, device: string): boolean =>
+  !device || (wfDevice ? wfDevice === device : device === DEFAULT_DEVICE);

--- a/src/lib/modules/market/model/market.api.ts
+++ b/src/lib/modules/market/model/market.api.ts
@@ -66,6 +66,9 @@ export const removeFx = createEffect((wf: RecordModel) =>
 export interface SavePayload {
   name: string;
   description?: string;
+  // which watch the face was made for — see market/lib/devices. Undefined leaves whatever the
+  // record already has: a draft save from the editor never asks, so it must not clear it.
+  device?: string;
   ownerId: string;
   bin: Uint8Array;
   preview: Blob;
@@ -81,6 +84,7 @@ export const saveFx = createEffect(async (p: SavePayload & { openedId?: string }
 
   fd.set("name", p.name);
   if (p.description !== undefined) fd.set("description", p.description);
+  if (p.device !== undefined) fd.set("device", p.device);
   fd.set("owner", p.ownerId);
   fd.set("published", p.published ? "true" : "false");
   fd.set("bin", new Blob([p.bin as BlobPart]), `${p.name || "watchface"}.bin`);

--- a/src/lib/modules/market/pages/market.svelte
+++ b/src/lib/modules/market/pages/market.svelte
@@ -7,6 +7,7 @@
   import { authModel } from "$lib/modules/auth/model";
   import { marketModel } from "../model";
   import { WatchfaceList } from "../components/watchface-list";
+  import { DEVICES, matchesDevice } from "../lib/devices";
 
   const { $user: user } = authModel;
   const {
@@ -39,10 +40,19 @@
     { value: "downloads", label: "Most downloaded" },
   ];
 
+  // "" — every watch. The shelf is mostly Watch 3 Pro faces right now, so a Watch Pro 2 owner
+  // needs a way to see their own watch's faces without us moving or hiding anyone's work.
+  let device = $state("");
+  const DEVICE_OPTIONS = [
+    { value: "", label: "All devices" },
+    ...DEVICES.map((d) => ({ value: d.value, label: d.label, short: d.short })),
+  ];
+
   const likeCount = (id: string) => $likes.filter((l) => l.watchface === id).length;
 
   const shown = $derived(
     (mine ? $myItems : $items.filter((wf) => Boolean(wf.owner)))
+      .filter((wf) => matchesDevice(wf.device, device))
       .filter((wf) => wf.name.toLowerCase().includes(query.trim().toLowerCase()))
       .toSorted((a, b) =>
         sort === "popular"
@@ -60,6 +70,7 @@
   $effect(() => {
     query;
     sort;
+    device;
     mine;
     visibleCount = PAGE;
   });
@@ -82,6 +93,9 @@
       />
     {/if}
     <SearchInput bind:value={query} />
+    <div class="device">
+      <Select bind:value={device} options={DEVICE_OPTIONS} />
+    </div>
     <div class="sort">
       <Select bind:value={sort} options={SORT_OPTIONS} />
     </div>
@@ -130,6 +144,9 @@
   .sort {
     width: 8.125rem;
   }
+  .device {
+    width: 9.5rem;
+  }
 
   @media (max-width: 767px) {
     .toolbar {
@@ -143,14 +160,16 @@
         flex: 1;
       }
     }
+    /* two selects don't fit beside the search on a phone — the search takes its own row */
     .toolbar > :global(.search) {
-      flex: 1;
+      flex: 1 1 100%;
       width: auto;
       margin-inline-start: 0;
     }
+    .device,
     .sort {
-      width: 7.5rem;
-      flex: none;
+      flex: 1;
+      width: auto;
     }
   }
   main {

--- a/src/lib/modules/market/pages/watchface.svelte
+++ b/src/lib/modules/market/pages/watchface.svelte
@@ -11,6 +11,7 @@
   import { LiveDial } from "../components/live-dial";
   import { BackBtn } from "$lib/shared/components/back-btn";
   import { List, ListItem } from "$lib/shared/components/list";
+  import { deviceLabel } from "../lib/devices";
   import { blur } from "svelte/transition";
 
   interface Props {
@@ -105,6 +106,7 @@
           <div class="title-row">
             <h1 class="name">{wf.name}</h1>
             {#if wf.type}<Badge>{wf.type}</Badge>{/if}
+            {#if deviceLabel(wf.device)}<Badge quiet>{deviceLabel(wf.device)}</Badge>{/if}
           </div>
 
           {#if wf.description}

--- a/src/lib/shared/components/badge/badge.svelte
+++ b/src/lib/shared/components/badge/badge.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
   import type { Snippet } from "svelte";
   interface Props {
+    // `quiet` — a tinted badge instead of the accent one, for a label that sits on every card
+    // (the device) rather than calling out an exception (Draft/Published)
+    quiet?: boolean;
     children?: Snippet;
   }
-  const { children }: Props = $props();
+  const { quiet = false, children }: Props = $props();
 </script>
 
-<span class="badge">{@render children?.()}</span>
+<span class="badge" class:quiet>{@render children?.()}</span>
 
 <style>
   .badge {
@@ -20,5 +23,10 @@
     border-radius: calc(var(--border-radius) / 2);
     color: var(--color-text);
     background: var(--color-accent);
+
+    &.quiet {
+      color: oklch(from var(--color-text) l c h / 70%);
+      background: oklch(from var(--color-text) l c h / 8%);
+    }
   }
 </style>

--- a/tests/market-devices.test.ts
+++ b/tests/market-devices.test.ts
@@ -1,0 +1,43 @@
+// The device filter decides what a Watch Pro 2 owner sees on the front page, and most of the
+// marketplace predates the field — so the untagged-face rule is the part worth pinning down.
+// Runs in the "unit" (node) vitest project.
+import { describe, test, expect } from "vitest";
+import {
+  DEFAULT_DEVICE,
+  DEVICES,
+  deviceLabel,
+  matchesDevice,
+} from "$lib/modules/market/lib/devices";
+
+describe("matchesDevice", () => {
+  test("no filter keeps everything", () => {
+    for (const wf of ["watch_pro_2", "watch_3_pro", undefined])
+      expect(matchesDevice(wf, "")).toBe(true);
+  });
+
+  test("a tagged face only shows on its own shelf", () => {
+    expect(matchesDevice("watch_3_pro", "watch_3_pro")).toBe(true);
+    expect(matchesDevice("watch_3_pro", "watch_pro_2")).toBe(false);
+    expect(matchesDevice("watch_3_pro", "watch_pro")).toBe(false);
+  });
+
+  test("an untagged face falls under the default device, not every shelf", () => {
+    expect(matchesDevice(undefined, DEFAULT_DEVICE)).toBe(true);
+    for (const d of DEVICES.filter((d) => d.value !== DEFAULT_DEVICE))
+      expect(matchesDevice(undefined, d.value)).toBe(false);
+  });
+
+  test("an empty-string device is untagged too — PocketBase writes '' for an unset select", () => {
+    expect(matchesDevice("", DEFAULT_DEVICE)).toBe(true);
+    expect(matchesDevice("", "watch_3_pro")).toBe(false);
+  });
+});
+
+describe("deviceLabel", () => {
+  test("badges only the devices we know", () => {
+    expect(deviceLabel("watch_3_pro")).toBe("Watch 3 Pro");
+    expect(deviceLabel("")).toBe("");
+    expect(deviceLabel(undefined)).toBe("");
+    expect(deviceLabel("watch_9_ultra")).toBe("");
+  });
+});

--- a/tests/watchface-card-device.browser.test.ts
+++ b/tests/watchface-card-device.browser.test.ts
@@ -1,0 +1,28 @@
+// The device badge is the card's only statement about which watch a face fits, so it has to be
+// silent rather than wrong: a record that doesn't claim a device — most of the marketplace,
+// which predates the field — must not get a badge guessed for it.
+import { test, expect } from "vitest";
+import { render } from "vitest-browser-svelte";
+import type { RecordModel } from "pocketbase";
+import { WatchfaceCard } from "$lib/modules/market/components/watchface-card";
+
+const face = (extra: Record<string, unknown>) =>
+  ({
+    id: "wf1",
+    name: "Test face",
+    owner: "u1",
+    published: true,
+    ...extra,
+  }) as unknown as RecordModel;
+
+test("a face that claims a device gets a badge", async () => {
+  const screen = await render(WatchfaceCard, { wf: face({ device: "watch_3_pro" }) });
+
+  await expect.element(screen.getByText("Watch 3 Pro")).toBeInTheDocument();
+});
+
+test("an untagged face gets none", async () => {
+  const screen = await render(WatchfaceCard, { wf: face({}) });
+
+  expect(screen.container.querySelectorAll(".badge")).toHaveLength(0);
+});


### PR DESCRIPTION
FMC-9. 51 of the 211 published faces carry the device in their **name** — "Chronoray (CMF Watch 3 Pro)" — because there was nowhere else to put it, and they are most of what a visitor sees first. A Watch Pro 2 owner lands on a front page that is mostly for a watch they don't own.

This adds the field the convention was standing in for. Nothing is moved, hidden or reclassified: the reader filters, the site doesn't.

## What changed

- `market/lib/devices.ts` — the three watches, the badge label, and the filter rule. New file, no logic anywhere else.
- **Publish dialog** — a required "Watch" select. No default on purpose: the editor renders both watches identically (same 466×466 panel), so guessing there would re-create the mislabelling this field exists to end. Publish stays disabled until it's picked.
- **Card + showcase page** — a quiet badge when the face claims a device, nothing when it doesn't.
- **Marketplace toolbar** — an "All devices" select beside the sort. On a phone the search moves to its own row so the two selects fit.
- `Badge` gains an optional `quiet` prop (tinted instead of accent). Existing usages are unchanged; the device badge sits on *every* card, and full accent orange there repaints the whole grid.
- Two tests: the filter rule (unit) and the badge's silence on an untagged face (browser).

## The untagged-face rule

An untagged face falls under the Watch Pro 2 rather than dropping out of every shelf. 160 of 211 faces predate the field, so a filter that hid all of them would be useless on day one. FMC only ever targeted the Watch Pro 2 — the editor, the BLE path, the seeded catalog — so that is the honest default. It decays correctly as creators publish with the field set, and the `ponytail:` note in `devices.ts` names the upgrade path.

## Needs the backend migration

This PR is inert until `pb_migrations/1753700000_device.js` lands in **fmc_pocketbase** (written, not committed — waiting on your call). It adds the `device` select and backfills the name suffix without touching the name text. Verified against a scratch copy of `pb_data`: applies, backfills, reverts cleanly, re-applies. Against today's published names it would set 51 records to `watch_3_pro` and leave 160 unset. **PocketBase caches the schema — restart the server after applying.**

## Verify

- `pnpm test` — 240 pass.
- Marketplace against prod data with the backfill simulated: "All devices" 211, "Watch 3 Pro" 51, "Watch Pro 2" the remaining 160.
- Without the migration applied the site behaves as it does today: every face is untagged, so "All devices" and "Watch Pro 2" show everything and "Watch 3 Pro" is empty.

## Cost

No new dependencies. +182/−7 across 9 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)